### PR TITLE
Updated installer.js file for WinAppDriver v0.5 release

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -4,14 +4,13 @@ import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
 
-// TODO: get release up on github so we can version it
-const WAD_VER = "0.4-beta";
+const WAD_VER = "0.5-beta";
 const WAD_DL = `https://github.com/Microsoft/WinAppDriver/releases/download/v${WAD_VER}/WindowsApplicationDriver.msi`;
-const WAD_DL_MD5 = "e1a4dc4d6bd37f32e26808ac6953e7e2";
+const WAD_DL_MD5 = "284759b1cadc0f6c9710a2e3e65316da";
 let WAD_INSTALL_PATH = process.env["ProgramFiles(x86)"] || process.env.ProgramFiles || "C:\\Program Files";
 WAD_INSTALL_PATH = path.resolve(WAD_INSTALL_PATH, "Windows Application Driver",
                                 "WinAppDriver.exe");
-const WAD_EXE_MD5 = "03285085e8240eabe2b510a54636f622";
+const WAD_EXE_MD5 = "33d7053477e138ba2826cd93d4890625";
 const WAD_GUID = "DDCD58BF-37CF-4758-A15E-A60E7CF20E41";
 
 async function downloadWAD () {


### PR DESCRIPTION
Modified the installer.js file to point to the [v0.5 release of WinAppDriver](https://github.com/Microsoft/WinAppDriver/releases/tag/v0.5-beta)

