### PR TITLE
adding multiple concurrent session support

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,28 +1,26 @@
-﻿import { BaseDriver } from 'appium-base-driver';
+﻿import _ from 'lodash';
+import { BaseDriver } from 'appium-base-driver';
 import { system } from 'appium-support';
-import WinAppDriver from './winappdriver';
+import { WinAppDriver, DEFAULT_WAD_HOST, DEFAULT_WAD_PORT } from './winappdriver';
 import logger from './logger';
-
-const WINAPPDRIVER_PORT = 4723;
-const WINAPPDRIVER_HOST = "localhost";
 
 // Appium instantiates this class
 class WindowsDriver extends BaseDriver {
   constructor (opts = {}, shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
     this.jwpProxyActive = false;
-    this.opts.port = opts.port || WINAPPDRIVER_PORT;
-    this.opts.address = opts.address || WINAPPDRIVER_HOST;
+    this.opts.address = opts.address || DEFAULT_WAD_HOST;
   }
 
-  async createSession (caps) {
+  async createSession (caps, reqCaps, curSessions) {
+
     if (!system.isWindows()) {
       throw new Error("WinAppDriver tests only run on Windows");
     }
     try {
       let sessionId;
       [sessionId] = await super.createSession(caps);
-      await this.startWinAppDriverSession();
+      await this.startWinAppDriverSession(curSessions);
       return [sessionId, caps];
     } catch (e) {
       await this.deleteSession();
@@ -30,10 +28,25 @@ class WindowsDriver extends BaseDriver {
     }
   }
 
-  async startWinAppDriverSession () {
+  getNextAvailablePort(curSessions) {
+    let newWADPort = DEFAULT_WAD_PORT;
+
+    // start at 4724 and go up till we find a port that isn't in use
+    while (_.find(curSessions, (o) => o.WADPort === newWADPort)) {
+      newWADPort++;
+    }
+
+    return newWADPort;
+  }
+
+  async startWinAppDriverSession (curSessions) {
+
+    this.opts.port = this.getNextAvailablePort(curSessions);
     this.winAppDriver = new WinAppDriver({
-      app: this.opts.app
+      app: this.opts.app,
+      port: this.opts.port
     });
+
     await this.winAppDriver.start();
     await this.winAppDriver.startSession(this.caps);
     this.proxyReqRes = this.winAppDriver.proxyReqRes.bind(this.winAppDriver);
@@ -62,6 +75,10 @@ class WindowsDriver extends BaseDriver {
   canProxy () {
     // we can always proxy to the WinAppDriver server
     return true;
+  }
+
+  get driverData () {
+    return {WADPort: this.opts.port};
   }
 }
 

--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -8,8 +8,8 @@ import cp from 'child_process';
 import B from 'bluebird';
 
 const REQD_PARAMS = ['app'];
-const DEFAULT_HOST = '127.0.0.1';
-const DEFAULT_PORT = "4823"; //  should be non-4723 to avoid conflict on the same box
+const DEFAULT_WAD_HOST = '127.0.0.1';
+const DEFAULT_WAD_PORT = 4724; //  should be non-4723 to avoid conflict on the same box
 
 class WinAppDriver extends events.EventEmitter {
   constructor (opts = {}) {
@@ -23,8 +23,8 @@ class WinAppDriver extends events.EventEmitter {
       this[req] = opts[req];
     }
 
-    this.proxyHost = host || DEFAULT_HOST;
-    this.proxyPort = port || DEFAULT_PORT;
+    this.proxyHost = host || DEFAULT_WAD_HOST;
+    this.proxyPort = port || DEFAULT_WAD_PORT;
     this.proc = null;
     this.state = WinAppDriver.STATE_STOPPED;
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
@@ -170,7 +170,7 @@ class WinAppDriver extends events.EventEmitter {
           "FOR /F \"usebackq\" %b in (`TASKLIST /FI \"PID eq %a\" ^| " +
           "findstr /I winappdriver.exe`) do (IF NOT %b==\"\" TASKKILL " +
           "/F /PID %a))";
-    log.info(`Killing any old WinAppDrivers, running: ${cmd}`);
+    log.info(`Killing any old WinAppDrivers on same port, running: ${cmd}`);
     try {
       // use cp.exec instead of teen process because of crazy windows quoting
       await (B.promisify(cp.exec))(cmd);
@@ -200,4 +200,5 @@ WinAppDriver.STATE_STARTING = 'starting';
 WinAppDriver.STATE_ONLINE = 'online';
 WinAppDriver.STATE_STOPPING = 'stopping';
 
+export { WinAppDriver, DEFAULT_WAD_HOST, DEFAULT_WAD_PORT};
 export default WinAppDriver;


### PR DESCRIPTION
This enables concurrent sessions by giving each WinAppDriver.exe instance a different port.  Port assignment is dynamic, starting at 5000 and when the process dies that port # is free again.

One example of why we need multiple concurrent sessions for Windows Desktop is sometimes a desktop session is needed to interact with system elements (like taskbar), while at the same time there is an active session with the application being tested.