### PR TITLE
Move to logger from appium-support

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,6 @@
-﻿import { getLogger } from 'appium-logger';
+import { logger } from 'appium-support';
 
-let logger = getLogger('WinAppDriver');
 
-export default logger;
+let log = logger.getLogger('WinAppDriver');
+
+export default log;

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   },
   "dependencies": {
     "appium-base-driver": "^2.0.1",
-    "appium-logger": "^2.1.0",
-    "appium-support": "^2.0.10",
+    "appium-support": "^2.5.0",
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.32",


### PR DESCRIPTION
Get rid of the deprecated `appium-logger` package.