### PR TITLE
removing app from required parameters for WinAppDriver

### DIFF
--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -7,7 +7,7 @@ import { WAD_INSTALL_PATH, verifyWAD } from './installer';
 import cp from 'child_process';
 import B from 'bluebird';
 
-const REQD_PARAMS = ['app'];
+const REQD_PARAMS = []; // XXYD 10-22-2017: removed app from required params because you can alternatively use appTopLevelWindow
 const DEFAULT_WAD_HOST = '127.0.0.1';
 const DEFAULT_WAD_PORT = 4724; //  should be non-4723 to avoid conflict on the same box
 


### PR DESCRIPTION
You can alternatively use appTopLevelWindow