### PR TITLE
resubmitting PR #15 - removing app from required parameters

### DIFF
--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -7,7 +7,7 @@ import { retryInterval } from 'asyncbox';
 import cp from 'child_process';
 import B from 'bluebird';
 
-const REQD_PARAMS = ['app'];
+const REQUIRED_PARAMS = []; // XXYD 1-5-2018: removed app from required params because you can alternatively use appTopLevelWindow
 const DEFAULT_WAD_HOST = '127.0.0.1';
 const DEFAULT_WAD_PORT = 4724; //  should be non-4723 to avoid conflict on the same box
 
@@ -16,7 +16,7 @@ class WinAppDriver extends events.EventEmitter {
     const {host, port} = opts;
     super();
 
-    for (let req of REQD_PARAMS) {
+    for (let req of REQUIRED_PARAMS) {
       if (!opts || !opts[req]) {
         throw new Error(`Option '${req}' is required!`);
       }


### PR DESCRIPTION
This is a Windows specific feature allowing you to not use "app" as a desired capability.  
Was originally submitted back in October and missed getting it in.  Would like to make sure this is included in future releases.