### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "6"
+  - "8"


### PR DESCRIPTION
Travis needs to be running for greenkeeper to work.

This is the most basic travis config for node, just running the install, and unit tests. We cannot run the functional tests since there is no Windows environment on Travis.