### PR TITLE
WinAppDriver v1.1RC Install

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -4,14 +4,14 @@ import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
 
-const WAD_VER = "1.0";
+const WAD_VER = "1.1-RC";
 const WAD_DL = `https://github.com/Microsoft/WinAppDriver/releases/download/v${WAD_VER}/WindowsApplicationDriver.msi`;
-const WAD_DL_MD5 = "efd463b8e97920bb35462616724ac7ed";
+const WAD_DL_MD5 = "7ec5c28e42fa90e0d3bd4c5c57c446be";
 
 let WAD_INSTALL_PATH = process.env["ProgramFiles(x86)"] || process.env.ProgramFiles || "C:\\Program Files";
 WAD_INSTALL_PATH = path.resolve(WAD_INSTALL_PATH, "Windows Application Driver",
                                 "WinAppDriver.exe");
-const WAD_EXE_MD5 = "0aef68b1149b9b9d78a4f7389854e954";
+const WAD_EXE_MD5 = "dcc1df722ad9bf7b93e077688e51b873";
 const WAD_GUID = "DDCD58BF-37CF-4758-A15E-A60E7CF20E41";
 
 async function downloadWAD () {


### PR DESCRIPTION
Updated Appium installer to install latest v1.1 RC of WinAppDriver. Please squash the two commits when accepting if possible. Thank you! 