### PR TITLE
Updated lib/installer.js to point to latest (official) WinAppDriver v1.1 release.

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -4,14 +4,14 @@ import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
 
-const WAD_VER = "1.1-RC";
+const WAD_VER = "1.1";
 const WAD_DL = `https://github.com/Microsoft/WinAppDriver/releases/download/v${WAD_VER}/WindowsApplicationDriver.msi`;
-const WAD_DL_MD5 = "7ec5c28e42fa90e0d3bd4c5c57c446be";
+const WAD_DL_MD5 = "1105548ca82ea32fb7be9ca4ea21ea58";
 
 let WAD_INSTALL_PATH = process.env["ProgramFiles(x86)"] || process.env.ProgramFiles || "C:\\Program Files";
 WAD_INSTALL_PATH = path.resolve(WAD_INSTALL_PATH, "Windows Application Driver",
                                 "WinAppDriver.exe");
-const WAD_EXE_MD5 = "dcc1df722ad9bf7b93e077688e51b873";
+const WAD_EXE_MD5 = "2d1b2adfb7b8d86fd890e260c1400ab7";
 const WAD_GUID = "DDCD58BF-37CF-4758-A15E-A60E7CF20E41";
 
 async function downloadWAD () {


### PR DESCRIPTION
Updated appium-windows-driver to point to the latest v1.1 version of WinAppDriver.

Thanks! 