### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
+  - "10"

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ if (require.main === module) {
   asyncify(main);
 }
 
-export { WindowsDriver,  commonCapConstraints };
+export { WindowsDriver, commonCapConstraints };
 
 export default WindowsDriver;
-

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -81,6 +81,7 @@ async function setupWAD () {
   }
 }
 
-export { downloadWAD, setupWAD, verifyWAD, installWAD, WAD_INSTALL_PATH,
-         WAD_GUID };
+export {
+  downloadWAD, setupWAD, verifyWAD, installWAD, WAD_INSTALL_PATH, WAD_GUID,
+};
 export default setupWAD;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,11 +1,11 @@
 import log from './logger';
-import { server as baseServer, routeConfiguringFunction  } from 'appium-base-driver';
+import { server as baseServer, routeConfiguringFunction } from 'appium-base-driver';
 import { WindowsDriver } from './driver';
 
-function startServer (port, address) {
+async function startServer (port, address) {
   let driver = new WindowsDriver({port, address});
   let router = routeConfiguringFunction(driver);
-  let server = baseServer(router, port, address);
+  let server = await baseServer(router, port, address);
   log.info(`WindowsDriver server listening on http://${address}:${port}`);
   return server;
 }

--- a/package.json
+++ b/package.json
@@ -24,14 +24,21 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "install-npm.js",
+    "lib",
+    "build/index.js",
+    "build/install-npm.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
     "appium-support": "^2.5.0",
     "asyncbox": "^2.3.1",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "lodash": "^4.6.1",
-    "punycode": "^2.0.0",
     "request-promise": "^4.2.2",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.7.0",
@@ -41,7 +48,7 @@
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "build": "gulp transpile",
     "mocha": "mocha",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "e2e-test": "gulp e2e-test",
     "watch": "gulp watch",
@@ -57,33 +64,23 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.0",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
     "appium-test-support": "1.0.0",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.0.1",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.8.11",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "pre-commit": "^1.2.2",
     "sinon": "^6.0.0",
     "wd": "^1.6.2"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/e2e/driver-e2e-specs.js
+++ b/test/e2e/driver-e2e-specs.js
@@ -19,7 +19,7 @@ describe('Driver', function () {
     await server.close();
   });
 
-  beforeEach(async function () {
+  beforeEach(function () {
     driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
   });
 


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.