### PR TITLE
#13173 WinAppDriver does not wait long startup an UWP app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ let driver = new WindowsDriver();
 await driver.createSession(defaultCaps);
 ```
 
+## WindowsDriver-specific capabilities
+
+|Capability|Description|Values|
+|----------|-----------|------|
+|`createSessionTimeout`|Timeout in milliseconds used to retry `WinAppDriver` session startup. This capability could be used as a workaround for the long startup times of UWP applications (aka `Failed to locate opened application window with appId: TestCompany.my_app4!App, and processId: 8480`). Default value `20000`|e.g., `15000`|
+
+
 ## Watch code for changes, re-transpile and run unit tests:
 
 ```

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -17,6 +17,9 @@ const desiredCapConstraints = {
     // recognize the cap,
     // but validate in the driver#validateDesiredCaps method
   },
+  createSessionTimeout: {
+    isNumber: true
+  },
   calendarFormat: {
     isString: true
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -3,6 +3,7 @@ import { BaseDriver } from 'appium-base-driver';
 import { system } from 'appium-support';
 import { WinAppDriver, DEFAULT_WAD_HOST, DEFAULT_WAD_PORT } from './winappdriver';
 import logger from './logger';
+import { desiredCapConstraints } from './desired-caps';
 
 const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/appium/compare_images')],
@@ -12,10 +13,9 @@ const NO_PROXY = [
 class WindowsDriver extends BaseDriver {
   constructor (opts = {}, shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
+    this.desiredCapConstraints = desiredCapConstraints;
     this.jwpProxyActive = false;
-
     this.jwpProxyAvoid = NO_PROXY;
-
     this.opts.address = opts.address || DEFAULT_WAD_HOST;
   }
 

--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -134,7 +134,7 @@ class WinAppDriver extends events.EventEmitter {
   async startSession (caps) {
 
     const createSessionTimeout = caps.createSessionTimeout || this.createSessionTimeout;
-    log.debug(`Start WinAppDriver session during createSessionTimeout = '${createSessionTimeout}' ms.`);
+    log.debug(`Starting WinAppDriver session. Will timeout in '${createSessionTimeout}' ms.`);
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
     let retryIteration = 0;
     let lastError;
@@ -162,7 +162,7 @@ class WinAppDriver extends events.EventEmitter {
       if (lastError) {
         throw (lastError);
       }
-      throw new Error(`Could not start WinAppDriver session during timeout '${createSessionTimeout}' ms.`);
+      throw new Error(`Could not start WinAppDriver session within ${createSessionTimeout} ms.`);
     }
   }
 

--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -147,7 +147,7 @@ class WinAppDriver extends events.EventEmitter {
         return true;
       } catch (error) {
         lastError = error;
-        log.warn(`Could not start WinAppDriver session error = '${error}', attempt = '${retryIteration}' from '${this.createSessionRetry}'`);
+        log.warn(`Could not start WinAppDriver session error = '${error.message}', attempt = '${retryIteration}' from '${this.createSessionRetry}'`);
         return false;
       }
     };
@@ -158,7 +158,7 @@ class WinAppDriver extends events.EventEmitter {
         intervalMs: 500
       });
     } catch (timeoutError) {
-      log.debug(`timeoutError was ${timeoutError}`);
+      log.debug(`timeoutError was ${timeoutError.message}`);
       if (lastError) {
         throw (lastError);
       }

--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -3,17 +3,18 @@ import { JWProxy } from 'appium-base-driver';
 import log from './logger';
 import { SubProcess } from 'teen_process';
 import { WAD_INSTALL_PATH, verifyWAD } from './installer';
-import { retryInterval } from 'asyncbox';
+import { retryInterval, waitForCondition } from 'asyncbox';
 import cp from 'child_process';
 import B from 'bluebird';
 
 const REQUIRED_PARAMS = []; // XXYD 1-5-2018: removed app from required params because you can alternatively use appTopLevelWindow
 const DEFAULT_WAD_HOST = '127.0.0.1';
-const DEFAULT_WAD_PORT = 4724; //  should be non-4723 to avoid conflict on the same box
+const DEFAULT_WAD_PORT = 4724; // should be non-4723 to avoid conflict on the same box;
+const DEFAULT_CREATE_SESSION_TIMEOUT_MS = 20000; // retry start session creation during the timeout in milliseconds
 
 class WinAppDriver extends events.EventEmitter {
   constructor (opts = {}) {
-    const {host, port} = opts;
+    const {host, port, createSessionTimeout} = opts;
     super();
 
     for (let req of REQUIRED_PARAMS) {
@@ -25,6 +26,7 @@ class WinAppDriver extends events.EventEmitter {
 
     this.proxyHost = host || DEFAULT_WAD_HOST;
     this.proxyPort = port || DEFAULT_WAD_PORT;
+    this.createSessionTimeout = createSessionTimeout || DEFAULT_CREATE_SESSION_TIMEOUT_MS;
     this.proc = null;
     this.state = WinAppDriver.STATE_STOPPED;
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
@@ -74,7 +76,7 @@ class WinAppDriver extends events.EventEmitter {
           this.changeState(WinAppDriver.STATE_STOPPED);
         }
       });
-      log.info(`Spawning winappdriver with: ${args.join(' ')}`);
+      log.info(`Spawning WinAppDriver with: ${args.join(' ')}`);
 
       // start subproc and wait for startDetector
       await this.proc.start(startDetector);
@@ -82,7 +84,7 @@ class WinAppDriver extends events.EventEmitter {
 
     } catch (e) {
       this.emit(WinAppDriver.EVENT_ERROR, e);
-      // just because we had an error doesn't mean the winappdriver process
+      // just because we had an error doesn't mean the WinAppDriver process
       // finished; we should clean up if necessary
       if (processIsAlive) {
         await this.proc.stop();
@@ -130,8 +132,38 @@ class WinAppDriver extends events.EventEmitter {
   }
 
   async startSession (caps) {
+
+    const createSessionTimeout = caps.createSessionTimeout || this.createSessionTimeout;
+    log.debug(`Start WinAppDriver session during createSessionTimeout = '${createSessionTimeout}' ms.`);
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
-    await this.jwproxy.command('/session', 'POST', {desiredCapabilities: caps});
+    let retryIteration = 0;
+    let lastError;
+
+    const condFn = async () => {
+      lastError = null;
+      try {
+        retryIteration++;
+        await this.jwproxy.command('/session', 'POST', {desiredCapabilities: caps});
+        return true;
+      } catch (error) {
+        lastError = error;
+        log.warn(`Could not start WinAppDriver session error = '${error}', attempt = '${retryIteration}' from '${this.createSessionRetry}'`);
+        return false;
+      }
+    };
+
+    try {
+      await waitForCondition(condFn, {
+        waitMs: createSessionTimeout,
+        intervalMs: 500
+      });
+    } catch (timeoutError) {
+      log.debug(`timeoutError was ${timeoutError}`);
+      if (lastError) {
+        throw (lastError);
+      }
+      throw new Error(`Could not start WinAppDriver session during timeout '${createSessionTimeout}' ms.`);
+    }
   }
 
   async stop (emitStates = true) {
@@ -202,5 +234,5 @@ WinAppDriver.STATE_STARTING = 'starting';
 WinAppDriver.STATE_ONLINE = 'online';
 WinAppDriver.STATE_STOPPING = 'stopping';
 
-export { WinAppDriver, DEFAULT_WAD_HOST, DEFAULT_WAD_PORT};
+export { WinAppDriver, DEFAULT_WAD_HOST, DEFAULT_WAD_PORT };
 export default WinAppDriver;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "watch": "gulp watch",
     "coverage": "gulp coveralls",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "precommit-test": "REPORTER=dot gulp once",
+    "precommit-test": "env REPORTER=dot bash -c 'gulp once'",
     "lint": "gulp lint",
     "lint:fix": "gulp lint --fix",
     "install": "node install-npm.js"


### PR DESCRIPTION
add create session timeout and waitForCondition to retry the session creation in case of an error
add 'createSessionTimeout' capability, WindowsDriver only