### PR TITLE
fix: Use built-in timeouts

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-import { errors } from 'appium-base-driver';
 import { util } from 'appium-support';
 
 
@@ -9,35 +7,11 @@ commands.findElOrEls = async function findElOrEls (strategy, selector, mult, con
   context = util.unwrapElement(context);
   const endpoint = `/element${context ? `/${context}/element` : ''}${mult ? 's' : ''}`;
 
-  let els;
-  try {
-    await this.implicitWaitForCondition(async () => {
-      try {
-        // This is either an array if mult is true or an object if mult is false
-        els = await this.winAppDriver.sendCommand(endpoint, 'POST', {
-          using: strategy,
-          value: selector,
-        });
-      } catch (e) {
-        els = [];
-      }
-      // we succeed if we get some elements
-      return !_.isEmpty(els);
-    });
-  } catch (err) {
-    if (!/Condition unmet/.test(err.message)) {
-      throw err;
-    }
-    // condition was not met setting res to empty array
-    els = [];
-  }
-  if (mult) {
-    return els;
-  }
-  if (_.isEmpty(els)) {
-    throw new errors.NoSuchElementError();
-  }
-  return els;
+  // This is either an array if mult is true or an object if mult is false
+  return await this.winAppDriver.sendCommand(endpoint, 'POST', {
+    using: strategy,
+    value: selector,
+  });
 };
 
 


### PR DESCRIPTION
WinAppDirver declares it does support implicit timeouts on its own, so there is no need to repeat this functionality on the driver level: https://github.com/microsoft/WinAppDriver/blob/master/Tests/WebDriverAPI/Timeouts.cs