### PR TITLE
refactor: Do not require hashsum match after driver download is completed

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -18,12 +18,12 @@ stages:
     - template: azure-templates/node_setup_steps.yml
     - script: npm run test
 
-# Integration tests cannot run in the hosted pool, because they require Administrator access:
+# Most of the integration tests cannot run in the hosted pool, because they require Administrator access:
 # > You are not running as an administrator so WinAppDriver cannot be installed for you; please reinstall as admin
 
-# - stage: Integration_Tests
-#   jobs:
-#   - job: Integration_Tests
-#     steps:
-#     - template: azure-templates/node_setup_steps.yml
-#     - script: npm run e2e-test
+- stage: Integration_Tests
+  jobs:
+  - job: Integration_Tests
+    steps:
+    - template: azure-templates/node_setup_steps.yml
+    - script: npm run e2e-test

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -45,7 +45,7 @@ async function downloadWAD () {
   await downloadFile(WAD_DL, tempFile);
   const secondsElapsed = timer.getDuration().asSeconds;
   const {size} = await fs.stat(tempFile);
-  log.debug(`WinAppServer installer (${util.toReadableSizeString(size)}) ` +
+  log.debug(`'${path.basename(WAD_DL)}' (${util.toReadableSizeString(size)}) ` +
     `has been downloaded in ${secondsElapsed.toFixed(3)}s`);
 
   // validate checksum

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -21,13 +21,22 @@ const WAD_GUID = 'DDCD58BF-37CF-4758-A15E-A60E7CF20E41';
 
 async function downloadFile (url, dstPath) {
   await new B((resolve, reject) => {
-    http.get(url, (response) => {
+    http.get(url, (res) => {
+      if (res.statusCode === 302) {
+        return downloadFile(res.headers.location, dstPath)
+          .then(resolve)
+          .catch(reject);
+      }
+      if (res.statusCode >= 300) {
+        return reject(new Error(`The request to download ${url} failed with error code ${res.statusCode}`));
+      }
+
       const dstStream = fs.createWriteStream(dstPath, {
         emitClose: true,
       });
-      response.pipe(dstStream);
+      res.pipe(dstStream);
       dstStream.once('error', (e) => {
-        response.unpipe(dstStream);
+        res.unpipe(dstStream);
         reject(e);
       });
       dstStream.once('close', resolve);

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -30,7 +30,7 @@ async function downloadFile (url, dstPath) {
         response.unpipe(dstStream);
         reject(e);
       });
-      dstStream.once('close', () => dstStream.close(resolve));
+      dstStream.once('close', resolve);
     }).on('error', (e) => {
       fs.rimraf(dstPath);
       reject(e);

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -31,9 +31,7 @@ async function downloadFile (url, dstPath) {
         reject(e);
       });
       dstStream.once('close', resolve);
-    }).on('error', (e) => {
-      reject(e);
-    });
+    }).on('error', reject);
   });
 }
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { system, fs, util } from 'appium-support';
+import { system, fs, util, timing } from 'appium-support';
 import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
@@ -41,7 +41,12 @@ async function downloadWAD () {
 
   // actually download the msi file
   log.info(`Downloading ${WAD_DL} to '${tempFile}'`);
+  const timer = new timing.Timer().start();
   await downloadFile(WAD_DL, tempFile);
+  const secondsElapsed = timer.getDuration().asSeconds;
+  const {size} = await fs.stat(tempFile);
+  log.debug(`'${WAD_DL}' (${util.toReadableSizeString(size)}) ` +
+    `has been downloaded in ${secondsElapsed.toFixed(3)}s`);
 
   // validate checksum
   const downloadedMd5 = await fs.md5(tempFile);

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -45,7 +45,7 @@ async function downloadWAD () {
   await downloadFile(WAD_DL, tempFile);
   const secondsElapsed = timer.getDuration().asSeconds;
   const {size} = await fs.stat(tempFile);
-  log.debug(`'${WAD_DL}' (${util.toReadableSizeString(size)}) ` +
+  log.debug(`WinAppServer installer (${util.toReadableSizeString(size)}) ` +
     `has been downloaded in ${secondsElapsed.toFixed(3)}s`);
 
   // validate checksum

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -20,11 +20,11 @@ const WAD_GUID = 'DDCD58BF-37CF-4758-A15E-A60E7CF20E41';
 
 
 async function downloadFile (url, dstPath) {
-  const dstStream = fs.createWriteStream(dstPath, {
-    emitClose: true,
-  });
   await new B((resolve, reject) => {
     http.get(url, (response) => {
+      const dstStream = fs.createWriteStream(dstPath, {
+        emitClose: true,
+      });
       response.pipe(dstStream);
       dstStream.once('error', (e) => {
         response.unpipe(dstStream);
@@ -32,7 +32,6 @@ async function downloadFile (url, dstPath) {
       });
       dstStream.once('close', resolve);
     }).on('error', (e) => {
-      fs.rimraf(dstPath);
       reject(e);
     });
   });

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -75,7 +75,7 @@ async function isWADChecksumOk () {
 
 const isAdmin = _.memoize(async function isAdmin () {
   try {
-    await exec('fsutil.exe', ['dirty', 'query', process.env.systemdrive || 'C:']);
+    await exec('fsutil.exe', ['dirty', 'query', process.env.SystemDrive || 'C:']);
     return true;
   } catch (ign) {
     return false;
@@ -97,7 +97,7 @@ async function setupWAD () {
     return;
   }
 
-  log.info(`WinAppDriver.exe doesn't exist at the correct version ${WAD_VER}, setting up`);
+  log.info(`WinAppDriver doesn't exist, setting up`);
 
   if (!await isAdmin()) {
     throw new Error(`You are not running as an administrator so WinAppDriver cannot be installed for you; please reinstall as admin`);

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,35 +1,54 @@
-import request from 'request-promise';
+import _ from 'lodash';
 import { system, fs } from 'appium-support';
 import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
+import http from 'http';
+import B from 'bluebird';
+import os from 'os';
+
 
 const WAD_VER = '1.2-RC';
 const WAD_DL = `https://github.com/Microsoft/WinAppDriver/releases/download/v${WAD_VER}/WindowsApplicationDriver.msi`;
 const WAD_DL_MD5 = 'dbaa9a3f7416c2b73cc5cd0e7452c8d0';
 
-let WAD_INSTALL_PATH = process.env['ProgramFiles(x86)'] || process.env.ProgramFiles || 'C:\\Program Files';
-WAD_INSTALL_PATH = path.resolve(WAD_INSTALL_PATH, 'Windows Application Driver',
-                                'WinAppDriver.exe');
+const WAD_INSTALL_PATH = path.resolve(
+  process.env['ProgramFiles(x86)'] || process.env.ProgramFiles || 'C:\\\\Program Files',
+  'Windows Application Driver', 'WinAppDriver.exe');
 const WAD_EXE_MD5 = '50d694ebfaa622ef7e4061c1bf52efe6';
 const WAD_GUID = 'DDCD58BF-37CF-4758-A15E-A60E7CF20E41';
 
+
+async function downloadFile (url, dstPath) {
+  const dstStream = fs.createWriteStream(dstPath, {
+    emitClose: true,
+  });
+  await new B((resolve, reject) => {
+    http.get(url, (response) => {
+      response.pipe(dstStream);
+      dstStream.once('error', (e) => {
+        response.unpipe(dstStream);
+        reject(e);
+      });
+      dstStream.once('close', () => dstStream.close(resolve));
+    }).on('error', (e) => {
+      fs.rimraf(dstPath);
+      reject(e);
+    });
+  });
+}
+
 async function downloadWAD () {
-  log.info(`Opening temp file to write WinAppDriver to...`);
-  let tempFile = path.resolve(process.env.TEMP, 'WinAppDriver.msi');
-  log.info(`Will write to ${tempFile}`);
+  const tempFile = path.resolve(os.tmpdir(), 'WinAppDriver.msi');
 
   // actually download the msi file
-  log.info(`Downloading ${WAD_DL}...`);
-  let body = await request.get({url: WAD_DL, encoding: 'binary'});
-  log.info(`Writing binary content to ${tempFile}...`);
-  await fs.writeFile(tempFile, body, {encoding: 'binary'});
+  log.info(`Downloading ${WAD_DL} to '${tempFile}'`);
+  await downloadFile(WAD_DL, tempFile);
 
   // validate checksum
-  let downloadedMd5 = await fs.md5(tempFile);
+  const downloadedMd5 = await fs.md5(tempFile);
   if (downloadedMd5 !== WAD_DL_MD5) {
-    throw new Error(`Checksum validation error: expected ${WAD_DL_MD5} but ` +
-                    `got ${downloadedMd5}`);
+    throw new Error(`Checksum validation error: expected ${WAD_DL_MD5} but got ${downloadedMd5}`);
   }
 
   return tempFile;
@@ -40,48 +59,50 @@ async function installWAD (msiPath) {
   await exec('msiexec', ['/i', msiPath, '/qn']);
 }
 
-async function verifyWAD () {
-  log.info(`You must use WinAppDriver version ${WAD_VER}`);
-  log.info(`Verifying WinAppDriver version ${WAD_VER} is installed via comparing the checksum.`);
-  return await fs.exists(WAD_INSTALL_PATH) &&
-         await fs.md5(WAD_INSTALL_PATH) === WAD_EXE_MD5;
+async function isWADInstalled () {
+  return await fs.exists(WAD_INSTALL_PATH);
 }
 
-async function isAdmin () {
-  let testFilePath = path.resolve('/', 'Windows', 'System32', 'wad-test.txt');
+async function isWADChecksumOk () {
+  return await fs.md5(WAD_INSTALL_PATH) === WAD_EXE_MD5;
+}
+
+const isAdmin = _.memoize(async function isAdmin () {
   try {
-    await fs.rimraf(testFilePath);
-    await fs.writeFile(testFilePath, 'foo');
+    await exec('fsutil.exe', ['dirty', 'query', process.env.systemdrive || 'C:']);
     return true;
   } catch (ign) {
     return false;
   }
-}
+});
 
 async function setupWAD () {
   if (!system.isWindows()) {
     throw new Error(`Can only download WinAppDriver on Windows!`);
   }
 
-  if (await verifyWAD()) {
-    log.info(`WinAppDriver.exe version ${WAD_VER} already exists with correct checksum, not re-downloading`);
+  if (await isWADInstalled()) {
+    if (await isWADChecksumOk()) {
+      log.info(`WinAppDriver version ${WAD_VER} already exists with correct checksum, not re-downloading`);
+    } else {
+      log.warn('WinAppDriver exists, but the checksum did not match. Not re-downloading. ' +
+        'Was it replaced manually?');
+    }
     return;
   }
 
   log.info(`WinAppDriver.exe doesn't exist at the correct version ${WAD_VER}, setting up`);
 
   if (!await isAdmin()) {
-    throw new Error(`WARNING: You are not running as an administrator so WinAppDriver cannot be installed for you; please reinstall as admin`);
+    throw new Error(`You are not running as an administrator so WinAppDriver cannot be installed for you; please reinstall as admin`);
   }
 
   const msiPath = await downloadWAD();
   await installWAD(msiPath);
-  if (!await verifyWAD()) {
-    throw new Error(`Installed version of WinAppDriver failed checksum check`);
-  }
 }
 
 export {
-  downloadWAD, setupWAD, verifyWAD, installWAD, WAD_INSTALL_PATH, WAD_GUID,
+  downloadWAD, setupWAD, isWADInstalled, isWADChecksumOk, installWAD,
+  WAD_INSTALL_PATH, WAD_GUID,
 };
 export default setupWAD;

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { system, fs } from 'appium-support';
+import { system, fs, util } from 'appium-support';
 import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
@@ -45,7 +45,7 @@ async function downloadFile (url, dstPath) {
 }
 
 async function downloadWAD () {
-  const tempFile = path.resolve(os.tmpdir(), 'WinAppDriver.msi');
+  const tempFile = path.resolve(os.tmpdir(), `${util.uuidV4()}.msi`);
 
   // actually download the msi file
   log.info(`Downloading ${WAD_DL} to '${tempFile}'`);
@@ -104,11 +104,15 @@ async function setupWAD () {
   }
 
   const msiPath = await downloadWAD();
-  await installWAD(msiPath);
+  try {
+    await installWAD(msiPath);
+  } finally {
+    await fs.rimraf(msiPath);
+  }
 }
 
 export {
   downloadWAD, setupWAD, isWADInstalled, isWADChecksumOk, installWAD,
-  WAD_INSTALL_PATH, WAD_GUID,
+  WAD_INSTALL_PATH, WAD_GUID, isAdmin,
 };
 export default setupWAD;

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -3,14 +3,15 @@ import { system, fs, util } from 'appium-support';
 import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
-import http from 'http';
 import B from 'bluebird';
 import os from 'os';
+import axios from 'axios';
 
 
 const WAD_VER = '1.2-RC';
 const WAD_DL = `https://github.com/Microsoft/WinAppDriver/releases/download/v${WAD_VER}/WindowsApplicationDriver.msi`;
 const WAD_DL_MD5 = 'dbaa9a3f7416c2b73cc5cd0e7452c8d0';
+const WAD_TIMEOUT = 5000; //ms
 
 const WAD_INSTALL_PATH = path.resolve(
   process.env['ProgramFiles(x86)'] || process.env.ProgramFiles || 'C:\\\\Program Files',
@@ -20,27 +21,18 @@ const WAD_GUID = 'DDCD58BF-37CF-4758-A15E-A60E7CF20E41';
 
 
 async function downloadFile (url, dstPath) {
-  await new B((resolve, reject) => {
-    http.get(url, (res) => {
-      if (res.statusCode === 302) {
-        return downloadFile(res.headers.location, dstPath)
-          .then(resolve)
-          .catch(reject);
-      }
-      if (res.statusCode >= 300) {
-        return reject(new Error(`The request to download ${url} failed with error code ${res.statusCode}`));
-      }
+  const writer = fs.createWriteStream(dstPath);
+  const response = await axios({
+    url,
+    method: 'GET',
+    responseType: 'stream',
+    timeout: WAD_TIMEOUT,
+  });
+  response.data.pipe(writer);
 
-      const dstStream = fs.createWriteStream(dstPath, {
-        emitClose: true,
-      });
-      res.pipe(dstStream);
-      dstStream.once('error', (e) => {
-        res.unpipe(dstStream);
-        reject(e);
-      });
-      dstStream.once('close', resolve);
-    }).on('error', reject);
+  await new B((resolve, reject) => {
+    writer.on('finish', resolve);
+    writer.on('error', reject);
   });
 }
 

--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -2,7 +2,7 @@ import events from 'events';
 import { JWProxy } from 'appium-base-driver';
 import log from './logger';
 import { SubProcess } from 'teen_process';
-import { WAD_INSTALL_PATH, verifyWAD } from './installer';
+import { WAD_INSTALL_PATH, isWADChecksumOk, isWADInstalled } from './installer';
 import { retryInterval, waitForCondition } from 'asyncbox';
 import cp from 'child_process';
 import B from 'bluebird';
@@ -33,8 +33,11 @@ class WinAppDriver extends events.EventEmitter {
   }
 
   async start () {
-    if (!await verifyWAD()) {
+    if (!await isWADInstalled()) {
       throw new Error('Could not verify WinAppDriver install; re-run install');
+    }
+    if (!await isWADChecksumOk()) {
+      log.warn('WinAppDriver exists, but the checksum did not match. Was it replaced manually?');
     }
 
     this.changeState(WinAppDriver.STATE_STARTING);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "appium-base-driver": "^5.4.3",
     "appium-support": "^2.41.0",
     "asyncbox": "^2.3.1",
+    "axios": "^0.19.2",
     "bluebird": "^3.5.1",
     "lodash": "^4.6.1",
     "source-map-support": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.6.1",
-    "request-promise": "^4.2.2",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.7.0",
     "yargs": "^15.0.1"

--- a/test/e2e/driver-e2e-specs.js
+++ b/test/e2e/driver-e2e-specs.js
@@ -15,7 +15,7 @@ describe('Driver', function () {
 
   before(async function () {
     if (!await isAdmin()) {
-      return this.skip();
+      return;
     }
 
     server = await startServer(TEST_PORT, TEST_HOST);
@@ -28,7 +28,11 @@ describe('Driver', function () {
     server = null;
   });
 
-  beforeEach(function () {
+  beforeEach(async function () {
+    if (!await isAdmin()) {
+      return;
+    }
+
     driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
   });
 
@@ -40,6 +44,10 @@ describe('Driver', function () {
   });
 
   it('should run a basic session using a real client', async function () {
+    if (!await isAdmin()) {
+      return this.skip();
+    }
+
     await driver.init({
       app: 'Microsoft.WindowsCalculator_8wekyb3d8bbwe!App',
       platformName: 'Windows',

--- a/test/e2e/driver-e2e-specs.js
+++ b/test/e2e/driver-e2e-specs.js
@@ -18,7 +18,9 @@ describe('Driver', async function () {
   let driver;
 
   before(async function () {
-    server = await startServer(TEST_PORT, TEST_HOST);
+    if (await isAdmin()) {
+      server = await startServer(TEST_PORT, TEST_HOST);
+    }
   });
 
   after(async function () {
@@ -29,7 +31,9 @@ describe('Driver', async function () {
   });
 
   beforeEach(function () {
-    driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+    if (server) {
+      driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+    }
   });
 
   afterEach(async function () {

--- a/test/e2e/driver-e2e-specs.js
+++ b/test/e2e/driver-e2e-specs.js
@@ -9,15 +9,15 @@ chai.use(chaiAsPromised);
 const TEST_PORT = 4788;
 const TEST_HOST = 'localhost';
 
-describe('Driver', function () {
+describe('Driver', async function () {
+  if (!await isAdmin()) {
+    return;
+  }
+
   let server;
   let driver;
 
   before(async function () {
-    if (!await isAdmin()) {
-      return;
-    }
-
     server = await startServer(TEST_PORT, TEST_HOST);
   });
 
@@ -28,11 +28,7 @@ describe('Driver', function () {
     server = null;
   });
 
-  beforeEach(async function () {
-    if (!await isAdmin()) {
-      return;
-    }
-
+  beforeEach(function () {
     driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
   });
 
@@ -44,10 +40,6 @@ describe('Driver', function () {
   });
 
   it('should run a basic session using a real client', async function () {
-    if (!await isAdmin()) {
-      return this.skip();
-    }
-
     await driver.init({
       app: 'Microsoft.WindowsCalculator_8wekyb3d8bbwe!App',
       platformName: 'Windows',

--- a/test/e2e/driver-e2e-specs.js
+++ b/test/e2e/driver-e2e-specs.js
@@ -2,21 +2,30 @@ import wd from 'wd';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { startServer } from '../../lib/server';
+import { isAdmin } from '../../lib/installer';
 chai.should();
 chai.use(chaiAsPromised);
 
 const TEST_PORT = 4788;
 const TEST_HOST = 'localhost';
 
-let server, driver;
-
 describe('Driver', function () {
+  let server;
+  let driver;
+
   before(async function () {
+    if (!await isAdmin()) {
+      return this.skip();
+    }
+
     server = await startServer(TEST_PORT, TEST_HOST);
   });
 
   after(async function () {
-    await server.close();
+    if (server) {
+      await server.close();
+    }
+    server = null;
   });
 
   beforeEach(function () {
@@ -24,14 +33,16 @@ describe('Driver', function () {
   });
 
   afterEach(async function () {
-    await driver.quit();
+    if (driver) {
+      await driver.quit();
+    }
+    driver = null;
   });
 
   it('should run a basic session using a real client', async function () {
     await driver.init({
       app: 'Microsoft.WindowsCalculator_8wekyb3d8bbwe!App',
       platformName: 'Windows',
-      deviceName: 'WindowsPC'
     });
     await driver.elementByName('Calculator');
   });

--- a/test/e2e/installer-e2e-specs.js
+++ b/test/e2e/installer-e2e-specs.js
@@ -1,31 +1,31 @@
-/* eslint-disable no-console */
-
-import { setupWAD, WAD_GUID } from '../../lib/installer';
-import { exec } from 'teen_process';
+import { setupWAD, downloadWAD, isAdmin } from '../../lib/installer';
+import { fs } from 'appium-support';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('downloading WAD', function () {
-  before(async function () {
-    // uninstall WAD first
-    try {
-      await exec('msiexec', [`/X{${WAD_GUID}}`, '/q']);
-    } catch (err) {
-      // if we get a 1605 error, that's ok, that means nothing was installed
-      // if we get some other kind of error, we should fail this test
-      if (err.code === 1603) {
-        console.log('You need to be an admin to run this test');
-      }
-      if (err.code !== 1605) {
-        throw err;
-      }
-    }
+describe('installer', function () {
+
+  it('should download the distributable', async function () {
+    const tmpPath = await downloadWAD();
+    (await fs.exists(tmpPath)).should.be.true;
   });
 
-  it('should download and validate WinAppDriver', async function () {
+  it('should fail if not admin', async function () {
+    if (await isAdmin()) {
+      return this.skip();
+    }
+
+    await setupWAD().should.be.rejectedWith(/administrator/);
+  });
+
+  it('should setup and validate WinAppDriver as admin', async function () {
+    if (!await isAdmin()) {
+      return this.skip();
+    }
+
     await setupWAD(); // contains its own verification of md5 so not much to do
   });
 });

--- a/test/e2e/installer-e2e-specs.js
+++ b/test/e2e/installer-e2e-specs.js
@@ -14,14 +14,18 @@ describe('installer', function () {
   });
 
   it('should fail if not admin', async function () {
-    if (!await isAdmin()) {
-      await setupWAD().should.be.rejectedWith(/administrator/);
+    if (await isAdmin()) {
+      return this.skip();
     }
+
+    await setupWAD().should.be.rejectedWith(/administrator/);
   });
 
   it('should setup and validate WinAppDriver as admin', async function () {
-    if (await isAdmin()) {
-      await setupWAD(); // contains its own verification of md5 so not much to do
+    if (!await isAdmin()) {
+      return this.skip();
     }
+
+    await setupWAD(); // contains its own verification of md5 so not much to do
   });
 });

--- a/test/e2e/installer-e2e-specs.js
+++ b/test/e2e/installer-e2e-specs.js
@@ -14,18 +14,14 @@ describe('installer', function () {
   });
 
   it('should fail if not admin', async function () {
-    if (await isAdmin()) {
-      return this.skip();
+    if (!await isAdmin()) {
+      await setupWAD().should.be.rejectedWith(/administrator/);
     }
-
-    await setupWAD().should.be.rejectedWith(/administrator/);
   });
 
   it('should setup and validate WinAppDriver as admin', async function () {
-    if (!await isAdmin()) {
-      return this.skip();
+    if (await isAdmin()) {
+      await setupWAD(); // contains its own verification of md5 so not much to do
     }
-
-    await setupWAD(); // contains its own verification of md5 so not much to do
   });
 });


### PR DESCRIPTION
https://github.com/appium/appium/issues/13261

Also:
- Switched file download to use Axios lib, which is more effective and to avoid possible memory leaks. 
- Made isAdmin helper result memoizable
- Enabled integration tests, which don't require admin