### PR TITLE
chore: Update port allocation logic

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -18,7 +18,10 @@ const NO_PROXY = [
 
 // The guard is needed to avoid dynamic system port allocation conflicts for
 // parallel driver sessions
-const PORT_ALLOCATION_GUARD = util.getLockFileGuard(path.resolve(os.tmpdir(), 'wad_port_guard'));
+const PORT_ALLOCATION_GUARD = util.getLockFileGuard(path.resolve(os.tmpdir(), 'wad_port_guard'), {
+  timeout: 5,
+  tryRecovery: true,
+});
 
 // Appium instantiates this class
 class WindowsDriver extends BaseDriver {
@@ -58,10 +61,14 @@ class WindowsDriver extends BaseDriver {
   }
 
   async allocatePort () {
+    if (this.opts.port) {
+      return;
+    }
+
     await PORT_ALLOCATION_GUARD(async () => {
       const [startPort, endPort] = [DEFAULT_WAD_PORT, 0xFFFF];
       try {
-        this.opts.port = this.opts.port || await findAPortNotInUse(startPort, endPort);
+        this.opts.port = await findAPortNotInUse(startPort, endPort);
       } catch (e) {
         logger.errorAndThrow(
           `Could not find any free port in range ${startPort}..${endPort}. ` +

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^7.0.0",
-    "appium-support": "^2.47.1",
+    "appium-support": "^2.49.0",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.6.1",


### PR DESCRIPTION
We had issues with file-based locking in UIA2 driver, so I aligned the implementation of Windows driver to not repeat the same mistakes.