### PR TITLE
fix: browserName for selenium-appium compatibility

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -5,6 +5,9 @@ const desiredCapConstraints = {
     isString: true,
     inclusionCaseInsensitive: ['Windows']
   },
+  browserName: {
+    isString: true
+  },
   platformVersion: {
     isString: true
   },


### PR DESCRIPTION
Add browserName to the desiredCapConstraints for compatibility with selenium-appium, since selenium-webdriver requires that browserName is present, so selenium-appium must provide it in capabilities.

Without the fix, we get the current error when trying to run `react-native-windows` application tests:
```
[BaseDriver] The following capabilities were provided, but are not recognized by Appium:
[BaseDriver]   browserName
```

Refs:
- https://github.com/react-native-windows/selenium-appium/blob/fadfd0a2e45603991e0ae908c1b5acbfe91b1792/src/WinAppDriver.ts#L10
- https://github.com/SeleniumHQ/selenium/blob/d8ddb4d83972df0f565ef65264bcb733e7a94584/javascript/node/selenium-webdriver/index.js#L613-L620

Note: There still seems to be more compatibility issues between `selenium-appium` and the 1.15.0 release of `appium-windows-driver`, but those are still being investigated.