### PR TITLE
fix: Change the capability name for the port number

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -35,7 +35,7 @@ const desiredCapConstraints = {
   address: {
     isString: true
   },
-  port: {
+  systemPort: {
     isNumber: true
   }
 };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -63,14 +63,14 @@ class WindowsDriver extends BaseDriver {
   }
 
   async allocatePort () {
-    if (this.opts.port) {
+    if (this.opts.systemPort) {
       return;
     }
 
     await PORT_ALLOCATION_GUARD(async () => {
       const [startPort, endPort] = [DEFAULT_WAD_PORT, 0xFFFF];
       try {
-        this.opts.port = await findAPortNotInUse(startPort, endPort);
+        this.opts.systemPort = await findAPortNotInUse(startPort, endPort);
       } catch (e) {
         logger.errorAndThrow(
           `Could not find any free port in range ${startPort}..${endPort}. ` +
@@ -84,7 +84,7 @@ class WindowsDriver extends BaseDriver {
 
     this.winAppDriver = new WinAppDriver({
       app: this.opts.app,
-      port: this.opts.port
+      port: this.opts.systemPort
     });
 
     await this.winAppDriver.start();


### PR DESCRIPTION
The problem there is that Appium umbrella driver writes all parameters provided as arguments into desired capabilities, so we are getting an unexpected conflict in this case where WAD port is set equal to the Appium port if the latter is provided via the command line. I've changed the capability name to `systemPort` in order to avoid that. See https://github.com/appium/appium/issues/14829#issuecomment-723135229 for more details 