### PR TITLE
feat: Add a possibility to execute prerun scripts before session startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ ms:waitForAppLaunch | Similar to `createSessionTimeout`, but in seconds and is a
 ms:experimental-webdriver | Enables experimental features and optimizations. See Appium Windows Driver release notes for more details on this capability. `false` by default.
 systemPort | The port number to execute Appium Windows Driver server listener on, for example `5556`. The port must not be occupied. The default starting port number for a new Appium Windows Driver session is `4724`. If this port is already busy then the next free port will be automatically selected.
 prerun | An object containing either `script` or `command` key. The value of each key must be a valid PowerShell script or command to be executed prior to the WinAppDriver session startup. See [Power Shell commands execution](#power-shell-commands-execution) for more details. Example: `{script: 'Get-Process outlook -ErrorAction SilentlyContinue'}`
+postrun | An object containing either `script` or `command` key. The value of each key must be a valid PowerShell script or command to be executed after WinAppDriver session is stopped. See [Power Shell commands execution](#power-shell-commands-execution) for more details.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ createSessionTimeout | Timeout in milliseconds used to retry Appium Windows Driv
 ms:waitForAppLaunch | Similar to `createSessionTimeout`, but in seconds and is applied on the server side. Enables Appium Windows Driver to wait for a defined amount of time after an app launch is initiated prior to attaching to the application session. The limit for this is 50 seconds.
 ms:experimental-webdriver | Enables experimental features and optimizations. See Appium Windows Driver release notes for more details on this capability. `false` by default.
 systemPort | The port number to execute Appium Windows Driver server listener on, for example `5556`. The port must not be occupied. The default starting port number for a new Appium Windows Driver session is `4724`. If this port is already busy then the next free port will be automatically selected.
-
+prerun | An object containing either `script` or `command` key. The value of each key must be a valid PowerShell script or command to be executed prior to the WinAppDriver session startup. See [Power Shell commands execution](#power-shell-commands-execution) for more details. Example: `{script: 'Get-Process outlook -ErrorAction SilentlyContinue'}`
 
 ## Example
 

--- a/lib/commands/powershell.js
+++ b/lib/commands/powershell.js
@@ -5,6 +5,7 @@ import { exec } from 'teen_process';
 import log from '../logger';
 import path from 'path';
 import B from 'bluebird';
+import { POWER_SHELL_FEATURE } from '../constants';
 
 const EXECUTION_POLICY = {
   REMOTE_SIGNED: 'RemoteSigned',
@@ -13,7 +14,6 @@ const EXECUTION_POLICY = {
 };
 const POWER_SHELL = 'powershell.exe';
 const POWER_SHELL_SCRIPT_PATTERN = /^powerShell$/;
-const POWER_SHELL_FEATURE = 'power_shell';
 
 const commands = {};
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,3 @@
+const POWER_SHELL_FEATURE = 'power_shell';
+
+export { POWER_SHELL_FEATURE };

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -34,6 +34,9 @@ const desiredCapConstraints = {
   },
   systemPort: {
     isNumber: true
+  },
+  prerun: {
+    isObject: true
   }
 };
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -37,6 +37,9 @@ const desiredCapConstraints = {
   },
   prerun: {
     isObject: true
+  },
+  postrun: {
+    isObject: true
   }
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { BaseDriver } from 'appium-base-driver';
 import { system } from 'appium-support';
 import { WinAppDriver } from './winappdriver';
-import logger from './logger';
+import log from './logger';
 import { desiredCapConstraints } from './desired-caps';
 import commands from './commands/index';
 
@@ -41,6 +41,23 @@ class WindowsDriver extends BaseDriver {
     this._screenRecorder = null;
   }
 
+  async executePrerun (spec) {
+    if (!_.isPlainObject(spec)) {
+      throw new Error(`'prerun' capability value must be an object`);
+    }
+    const { script, command } = spec;
+    if (_.isString(command)) {
+      log.debug(`Executing PowerShell prerun command`);
+      await this.execPowerShell({command});
+    } else if (_.isString(script)) {
+      log.debug(`Executing PowerShell prerun script`);
+      await this.execPowerShell({script});
+    } else {
+      throw new Error(`'prerun' capability value must either contain ` +
+        `'script' or 'command' entry of string type`);
+    }
+  }
+
   async createSession (...args) {
     if (!system.isWindows()) {
       throw new Error('WinAppDriver tests only run on Windows');
@@ -48,6 +65,9 @@ class WindowsDriver extends BaseDriver {
 
     try {
       const [sessionId, caps] = await super.createSession(...args);
+      if (caps.prerun) {
+        await this.executePrerun(caps.prerun);
+      }
       await this.startWinAppDriverSession();
       return [sessionId, caps];
     } catch (e) {
@@ -68,7 +88,7 @@ class WindowsDriver extends BaseDriver {
   }
 
   async deleteSession () {
-    logger.debug('Deleting WinAppDriver session');
+    log.debug('Deleting WinAppDriver session');
     await this._screenRecorder?.stop(true);
     await this.winAppDriver?.stop();
     this.resetState();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -5,6 +5,7 @@ import { WinAppDriver } from './winappdriver';
 import log from './logger';
 import { desiredCapConstraints } from './desired-caps';
 import commands from './commands/index';
+import { POWER_SHELL_FEATURE } from 'constants';
 
 const NO_PROXY = [
   ['GET', new RegExp('^/session/[^/]+/appium/(?!app/)[^/]+')],
@@ -47,9 +48,11 @@ class WindowsDriver extends BaseDriver {
     }
     const { script, command } = spec;
     if (_.isString(command)) {
+      this.ensureFeatureEnabled(POWER_SHELL_FEATURE);
       log.debug(`Executing PowerShell prerun command`);
       await this.execPowerShell({command});
     } else if (_.isString(script)) {
+      this.ensureFeatureEnabled(POWER_SHELL_FEATURE);
       log.debug(`Executing PowerShell prerun script`);
       await this.execPowerShell({script});
     } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -42,25 +42,6 @@ class WindowsDriver extends BaseDriver {
     this._screenRecorder = null;
   }
 
-  async executePrerun (spec) {
-    if (!_.isPlainObject(spec)) {
-      throw new Error(`'prerun' capability value must be an object`);
-    }
-    const { script, command } = spec;
-    if (_.isString(command)) {
-      this.ensureFeatureEnabled(POWER_SHELL_FEATURE);
-      log.debug(`Executing PowerShell prerun command`);
-      await this.execPowerShell({command});
-    } else if (_.isString(script)) {
-      this.ensureFeatureEnabled(POWER_SHELL_FEATURE);
-      log.debug(`Executing PowerShell prerun script`);
-      await this.execPowerShell({script});
-    } else {
-      throw new Error(`'prerun' capability value must either contain ` +
-        `'script' or 'command' entry of string type`);
-    }
-  }
-
   async createSession (...args) {
     if (!system.isWindows()) {
       throw new Error('WinAppDriver tests only run on Windows');
@@ -69,7 +50,16 @@ class WindowsDriver extends BaseDriver {
     try {
       const [sessionId, caps] = await super.createSession(...args);
       if (caps.prerun) {
-        await this.executePrerun(caps.prerun);
+        log.info('Executing prerun PowerShell script');
+        if (!_.isString(this.prerun.command) && !_.isString(this.prerun.script)) {
+          throw new Error(`'prerun' capability value must either contain ` +
+            `'script' or 'command' entry of string type`);
+        }
+        this.ensureFeatureEnabled(POWER_SHELL_FEATURE);
+        const output = await this.execPowerShell(caps.prerun);
+        if (output) {
+          log.info(`Prerun script output: ${output}`);
+        }
       }
       await this.startWinAppDriverSession();
       return [sessionId, caps];
@@ -94,6 +84,25 @@ class WindowsDriver extends BaseDriver {
     log.debug('Deleting WinAppDriver session');
     await this._screenRecorder?.stop(true);
     await this.winAppDriver?.stop();
+
+    if (this.opts.postrun) {
+      if (!_.isString(this.opts.postrun.command) && !_.isString(this.opts.postrun.script)) {
+        log.error(`'postrun' capability value must either contain ` +
+          `'script' or 'command' entry of string type`);
+      } else {
+        log.info('Executing postrun PowerShell script');
+        try {
+          this.ensureFeatureEnabled(POWER_SHELL_FEATURE);
+          const output = await this.execPowerShell(this.opts.postrun);
+          if (output) {
+            log.info(`Postrun script output: ${output}`);
+          }
+        } catch (e) {
+          log.error(e.message);
+        }
+      }
+    }
+
     this.resetState();
 
     await super.deleteSession();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -51,7 +51,7 @@ class WindowsDriver extends BaseDriver {
       const [sessionId, caps] = await super.createSession(...args);
       if (caps.prerun) {
         log.info('Executing prerun PowerShell script');
-        if (!_.isString(this.prerun.command) && !_.isString(this.prerun.script)) {
+        if (!_.isString(caps.prerun.command) && !_.isString(caps.prerun.script)) {
           throw new Error(`'prerun' capability value must either contain ` +
             `'script' or 'command' entry of string type`);
         }


### PR DESCRIPTION
We have a command to run PS scripts, but this could only be executed during a session. And sometimes it is necessary to perform some preparation steps right before the session is actually executed. Then `prerun` capability could be in use