### PR TITLE
feat: make windows driver appium 2.0 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,14 @@
   "directories": {
     "lib": "lib"
   },
+  "appium": {
+    "driverName": "windows",
+    "automationName": "Windows",
+    "platformNames": [
+      "Windows"
+    ],
+    "mainClass": "WindowsDriver"
+  },
   "files": [
     "index.js",
     "install-npm.js",


### PR DESCRIPTION
fix https://github.com/appium/appium/issues/15056

@mykola-mokhnach not sure what automation name should be: "Windows" or "WinAppDriver"?