### PR TITLE
Proper call of execPowerShell method from execute

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -19,7 +19,7 @@ commands.execute = async function execute (script, args) {
     return await this.executeWindowsCommand(script, _.isArray(args) ? args[0] : args);
   } else if (POWER_SHELL_SCRIPT_PATTERN.test(script)) {
     this.ensureFeatureEnabled(POWER_SHELL_FEATURE);
-    return await this.execPowerShell(script, _.isArray(args) ? _.first(args) : args);
+    return await this.execPowerShell(_.isArray(args) ? _.first(args) : args);
   }
   throw new errors.NotImplementedError();
 };


### PR DESCRIPTION
Now if I execute `driver.execute_script('powerShell', {'command': "Some PS command"})`, the value `powerShell` will be passed to `execPowerShell` method and driver throw `Power Shell script/command must not be empty` exception.
This fix enable to execute PS scripts/commands via `execute` API method. 