### PR TITLE
Changed parameter name for Set-ExecutionPolicy cmdlet

### DIFF
--- a/lib/commands/powershell.js
+++ b/lib/commands/powershell.js
@@ -68,7 +68,7 @@ commands.execPowerShell = async function execPowerShell (opts = {}) {
         log.debug(`Temporarily changing Power Shell execution policy to ${EXECUTION_POLICY.REMOTE_SIGNED} ` +
           'to run the given script');
         await exec(POWER_SHELL, [
-          '-command', `Set-ExecutionPolicy -Execution-Policy ${EXECUTION_POLICY.REMOTE_SIGNED} -Scope CurrentUser`
+          '-command', `Set-ExecutionPolicy -ExecutionPolicy ${EXECUTION_POLICY.REMOTE_SIGNED} -Scope CurrentUser`
         ]);
       } else {
         // There is no need to change the policy, scripts are allowed
@@ -88,7 +88,7 @@ commands.execPowerShell = async function execPowerShell (opts = {}) {
       (async () => {
         if (userExecutionPolicy) {
           await exec(POWER_SHELL, [
-            '-command', `Set-ExecutionPolicy -Execution-Policy ${userExecutionPolicy} -Scope CurrentUser`
+            '-command', `Set-ExecutionPolicy -ExecutionPolicy ${userExecutionPolicy} -Scope CurrentUser`
           ]);
         }
       })(),


### PR DESCRIPTION
Hi!
Fix parameter name for [Set-ExecutionPolicy](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy) cmdlet from `-Execution-Policy` to `-ExecutionPolicy`.