### PR TITLE
fix: Check for existence of WAD path

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -11,9 +11,19 @@ const WAD_DL = `https://github.com/Microsoft/WinAppDriver/releases/download/v${W
 const WAD_DL_MD5 = 'dbaa9a3f7416c2b73cc5cd0e7452c8d0';
 const WAD_TIMEOUT = 5000; //ms
 
-const WAD_INSTALL_PATH = path.resolve(
-  process.env['ProgramFiles(x86)'] || process.env.ProgramFiles || 'C:\\\\Program Files',
-  'Windows Application Driver', 'WinAppDriver.exe');
+// check whether or not the path actually exists
+function resolveDriver (folder) {
+  return path.resolve(folder, 'Windows Application Driver', 'WinAppDriver.exe');
+}
+
+// get the actual location where the WinAppDriver is installed
+const WAD_INSTALL_PATH = resolveDriver(
+  [
+    process.env['ProgramFiles(x86)'],
+    process.env.ProgramFiles,
+    'C:\\\\Program Files',
+  ].find((folder) => resolveDriver(folder))
+);
 const WAD_EXE_MD5 = '50d694ebfaa622ef7e4061c1bf52efe6';
 const WAD_GUID = 'DDCD58BF-37CF-4758-A15E-A60E7CF20E41';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-windows-driver",
-  "version": "1.20.0",
+  "version": "1.19.0",
   "description": "Teams fork of Appium bridge to WinAppDriver",
   "keywords": [
     "appium",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appium-windows-driver",
   "version": "1.19.0",
-  "description": "Teams fork of Appium bridge to WinAppDriver",
+  "description": "Appium bridge to WinAppDriver",
   "keywords": [
     "appium",
     "windows",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appium-windows-driver",
-  "version": "1.19.0",
-  "description": "Appium bridge to WinAppDriver",
+  "version": "1.20.0",
+  "description": "Teams fork of Appium bridge to WinAppDriver",
   "keywords": [
     "appium",
     "windows",


### PR DESCRIPTION
This PR is to fix an issue that occurs when trying to use appium-windows-driver on ARM-based Windows. 

The current implementation will always set WAD_INSTALL_PATH to 'C:\Program Files (x86)\Windows Application Driver\WinAppDriver.exe', regardless of whether or not that's the correct path. We need to add a check to make sure the path we assign actually exists.