### PR TITLE
feat: Bump WAD installer version to 1.2.99

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
 import ES6Error from 'es6-error';
-
+import { queryRegistry } from './registry';
 
 const WAD_VER = '1.2.99';
 const WAD_DOWNLOAD_MD5 = Object.freeze({
@@ -20,9 +20,18 @@ const POSSIBLE_WAD_INSTALL_ROOTS = [
   `${process.env.SystemDrive || 'C:'}\\\\Program Files`,
 ];
 const WAD_EXE_NAME = 'WinAppDriver.exe';
-// const UNINSTALL_REG_ROOT = 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall';
-// const NAME_ENTRY_VALUE = 'Windows Application Driver';
-// const NAME_ENTRY_KEY = 'DisplayName';
+const UNINSTALL_REG_ROOT = 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall';
+const REG_ENTRY_VALUE = 'Windows Application Driver';
+const REG_ENTRY_KEY = 'DisplayName';
+const REG_ENTRY_TYPE = 'REG_SZ';
+const INST_LOCATION_SCRIPT_BY_GUID = (guid) => `
+Set installer = CreateObject("WindowsInstaller.Installer")
+Set session = installer.OpenProduct("${guid}")
+session.DoAction("CostInitialize")
+session.DoAction("CostFinalize")
+WScript.Echo session.Property("INSTALLFOLDER")
+`.replace(/\n/g, '\r\n');
+
 
 function generateWadDownloadLink () {
   const wadArch = ARCH_MAPPING[process.arch];
@@ -34,6 +43,18 @@ function generateWadDownloadLink () {
     `/releases/download/v${WAD_VER}/WindowsApplicationDriver-${WAD_VER}-win-${wadArch}.exe`;
 }
 
+async function fetchMsiInstallLocation (installerGuid) {
+  const tmpRoot = await tempDir.openDir();
+  const scriptPath = path.join(tmpRoot, 'get_wad_inst_location.vbs');
+  try {
+    await fs.writeFile(scriptPath, INST_LOCATION_SCRIPT_BY_GUID(installerGuid), 'latin1');
+    const {stdout} = await exec('cscript.exe', ['/Nologo', scriptPath]);
+    return _.trim(stdout);
+  } finally {
+    await fs.rimraf(tmpRoot);
+  }
+}
+
 class WADNotFoundError extends ES6Error {}
 
 const getWADExecutablePath = _.memoize(async function getWADInstallPath () {
@@ -42,11 +63,38 @@ const getWADExecutablePath = _.memoize(async function getWADInstallPath () {
     // remove unset env variables
     .filter(Boolean)
     // construct full path
-    .map((root) => path.resolve(root, 'Windows Application Driver', WAD_EXE_NAME));
+    .map((root) => path.resolve(root, REG_ENTRY_VALUE, WAD_EXE_NAME));
   for (const result of pathCandidates) {
     if (await fs.exists(result)) {
       return result;
     }
+  }
+  log.debug('Did not detect WAD executable at any of the default install locations');
+  log.debug('Checking the system registry for the corresponding MSI entry');
+  try {
+    const uninstallEntries = await queryRegistry(UNINSTALL_REG_ROOT);
+    const wadEntry = uninstallEntries.find(({key, type, value}) =>
+      key === REG_ENTRY_KEY && value === REG_ENTRY_VALUE && type === REG_ENTRY_TYPE
+    );
+    if (wadEntry) {
+      log.debug(`Found MSI entry: ${JSON.stringify(wadEntry)}`);
+      const installerGuid = _.last(wadEntry.root.split('\\'));
+      // WAD MSI installer leaves InstallLocation registry value empty,
+      // so we need to be hacky here
+      const result = path.join(await fetchMsiInstallLocation(installerGuid), WAD_EXE_NAME);
+      log.debug(`Checking if WAD exists at '${result}'`);
+      if (await fs.exists(result)) {
+        return result;
+      }
+      log.debug(result);
+    } else {
+      log.debug('No WAD MSI entries have been found');
+    }
+  } catch (e) {
+    if (e.stderr) {
+      log.debug(e.stderr);
+    }
+    log.debug(e.stack);
   }
   throw new WADNotFoundError(`${WAD_EXE_NAME} has not been found in any of these ` +
     `locations: ${pathCandidates}. Is it installed?`);
@@ -61,14 +109,11 @@ async function downloadWAD () {
   const expectedMd5 = WAD_DOWNLOAD_MD5[process.arch];
   if (downloadedMd5 !== expectedMd5) {
     await fs.rimraf(installerPath);
-    throw new Error(`Checksum validation error: expected ${expectedMd5} but got ${downloadedMd5}`);
+    throw new Error(
+      `Installer executable checksum validation error: expected ${expectedMd5} but got ${downloadedMd5}`
+    );
   }
   return installerPath;
-}
-
-async function installWAD (installerPath) {
-  log.info(`Running installer`);
-  await exec(installerPath, ['/install', '/quiet', '/norestart']);
 }
 
 const isAdmin = _.memoize(async function isAdmin () {
@@ -99,15 +144,13 @@ async function setupWAD () {
   }
 
   const installerPath = await downloadWAD();
+  log.info('Running installer');
   try {
-    await installWAD(installerPath);
+    await exec(installerPath, ['/install', '/quiet', '/norestart']);
   } finally {
     await fs.rimraf(installerPath);
   }
 }
 
-export {
-  downloadWAD, setupWAD, installWAD,
-  getWADExecutablePath, isAdmin,
-};
+export { downloadWAD, setupWAD, getWADExecutablePath, isAdmin };
 export default setupWAD;

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,14 +1,18 @@
 import _ from 'lodash';
-import { system, fs, util, net, tempDir } from 'appium-support';
+import { system, fs, net, tempDir } from 'appium-support';
 import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
 import ES6Error from 'es6-error';
 
 
-const WAD_VER = '1.2-RC';
-const WAD_DOWNLOAD_LINK = `https://github.com/Microsoft/WinAppDriver/releases/download/v${WAD_VER}/WindowsApplicationDriver.msi`;
-const WAD_DOWNLOAD_MD5 = 'dbaa9a3f7416c2b73cc5cd0e7452c8d0';
+const WAD_VER = '1.2.99';
+const WAD_DOWNLOAD_MD5 = Object.freeze({
+  x32: '23745e6ed373bc969ff7c4493e32756a',
+  x64: '2923fc539f389d47754a7521ee50108e',
+  arm64: 'b9af4222a3fb0d688ecfbf605d1c4500',
+});
+const ARCH_MAPPING = Object.freeze({x32: 'x86', x64: 'x64', arm64: 'arm64'});
 const WAD_DOWNLOAD_TIMEOUT_MS = 60000;
 const POSSIBLE_WAD_INSTALL_ROOTS = [
   process.env['ProgramFiles(x86)'],
@@ -16,8 +20,19 @@ const POSSIBLE_WAD_INSTALL_ROOTS = [
   `${process.env.SystemDrive || 'C:'}\\\\Program Files`,
 ];
 const WAD_EXE_NAME = 'WinAppDriver.exe';
-const WAD_EXE_MD5 = '50d694ebfaa622ef7e4061c1bf52efe6';
-// const WAD_GUID = 'DDCD58BF-37CF-4758-A15E-A60E7CF20E41';
+// const UNINSTALL_REG_ROOT = 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall';
+// const NAME_ENTRY_VALUE = 'Windows Application Driver';
+// const NAME_ENTRY_KEY = 'DisplayName';
+
+function generateWadDownloadLink () {
+  const wadArch = ARCH_MAPPING[process.arch];
+  if (!wadArch) {
+    throw new Error(`System architecture '${process.arch}' is not supported by Windows Application Driver. ` +
+      `The only supported architectures are: ${_.keys(ARCH_MAPPING)}`);
+  }
+  return `https://github.com/Microsoft/WinAppDriver` +
+    `/releases/download/v${WAD_VER}/WindowsApplicationDriver-${WAD_VER}-win-${wadArch}.exe`;
+}
 
 class WADNotFoundError extends ES6Error {}
 
@@ -38,28 +53,22 @@ const getWADExecutablePath = _.memoize(async function getWADInstallPath () {
 });
 
 async function downloadWAD () {
-  const tempFile = path.resolve(await tempDir.staticDir(), `${util.uuidV4()}.msi`);
-
-  // actually download the msi file
-  log.info(`Downloading ${WAD_DOWNLOAD_LINK} to '${tempFile}'`);
-  await net.downloadFile(WAD_DOWNLOAD_LINK, tempFile, {timeout: WAD_DOWNLOAD_TIMEOUT_MS});
-
-  // validate checksum
-  const downloadedMd5 = await fs.md5(tempFile);
-  if (downloadedMd5 !== WAD_DOWNLOAD_MD5) {
-    throw new Error(`Checksum validation error: expected ${WAD_DOWNLOAD_MD5} but got ${downloadedMd5}`);
+  const downloadLink = generateWadDownloadLink();
+  const installerPath = path.resolve(await tempDir.staticDir(), path.basename(downloadLink));
+  log.info(`Downloading ${downloadLink} to '${installerPath}'`);
+  await net.downloadFile(downloadLink, installerPath, {timeout: WAD_DOWNLOAD_TIMEOUT_MS});
+  const downloadedMd5 = await fs.md5(installerPath);
+  const expectedMd5 = WAD_DOWNLOAD_MD5[process.arch];
+  if (downloadedMd5 !== expectedMd5) {
+    await fs.rimraf(installerPath);
+    throw new Error(`Checksum validation error: expected ${expectedMd5} but got ${downloadedMd5}`);
   }
-
-  return tempFile;
+  return installerPath;
 }
 
-async function installWAD (msiPath) {
-  log.info(`Running MSI installer`);
-  await exec('msiexec', ['/i', msiPath, '/qn']);
-}
-
-async function isWADChecksumOk (executablePath) {
-  return await fs.md5(executablePath) === WAD_EXE_MD5;
+async function installWAD (installerPath) {
+  log.info(`Running installer`);
+  await exec(installerPath, ['/install', '/quiet', '/norestart']);
 }
 
 const isAdmin = _.memoize(async function isAdmin () {
@@ -77,14 +86,7 @@ async function setupWAD () {
   }
 
   try {
-    const executablePath = await getWADExecutablePath();
-    if (await isWADChecksumOk(executablePath)) {
-      log.info(`WinAppDriver version ${WAD_VER} already exists with correct checksum, not re-downloading`);
-    } else {
-      log.warn('WinAppDriver exists, but the checksum did not match. Not re-downloading. ' +
-        'Was it replaced manually?');
-    }
-    return;
+    return await getWADExecutablePath();
   } catch (e) {
     if (!(e instanceof WADNotFoundError)) {
       throw e;
@@ -96,16 +98,16 @@ async function setupWAD () {
     throw new Error(`You are not running as an administrator so WinAppDriver cannot be installed for you; please reinstall as admin`);
   }
 
-  const msiPath = await downloadWAD();
+  const installerPath = await downloadWAD();
   try {
-    await installWAD(msiPath);
+    await installWAD(installerPath);
   } finally {
-    await fs.rimraf(msiPath);
+    await fs.rimraf(installerPath);
   }
 }
 
 export {
-  downloadWAD, setupWAD, isWADChecksumOk, installWAD,
+  downloadWAD, setupWAD, installWAD,
   getWADExecutablePath, isAdmin,
 };
 export default setupWAD;

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { system, fs, net, tempDir } from 'appium-support';
+import { system, fs, util, net, tempDir } from 'appium-support';
 import path from 'path';
 import { exec } from 'teen_process';
 import log from './logger';
@@ -102,7 +102,8 @@ const getWADExecutablePath = _.memoize(async function getWADInstallPath () {
 
 async function downloadWAD () {
   const downloadLink = generateWadDownloadLink();
-  const installerPath = path.resolve(await tempDir.staticDir(), path.basename(downloadLink));
+  const installerPath = path.resolve(await tempDir.staticDir(),
+    `wad_installer_${WAD_VER}_${util.uuidV4()}.exe`);
   log.info(`Downloading ${downloadLink} to '${installerPath}'`);
   await net.downloadFile(downloadLink, installerPath, {timeout: WAD_DOWNLOAD_TIMEOUT_MS});
   const downloadedMd5 = await fs.md5(installerPath);

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -53,7 +53,7 @@ function parseRegQueryOutput (output) {
  * The lookup is done under the same registry branch that the current process
  * system architecture.
  *
- * @param {string} root The registry key name, which consists of tro parts:
+ * @param {string} root The registry key name, which consists of two parts:
  * - The root key: HKLM | HKCU | HKCR | HKU | HKCC
  * - The subkey under the selected root key, for example \Software\Microsoft
  * @returns {RegEntry[]} List of matched RegEntry instances or an empty list

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,0 +1,72 @@
+import _ from 'lodash';
+import { exec } from 'teen_process';
+
+const REG = 'reg.exe';
+const ENTRY_PATTERN = /^\s+(\w+)\s+([A-Z_]+)\s*(.*)/;
+
+function parseRegEntries (root, block) {
+  return (_.isEmpty(block) || _.isEmpty(root))
+    ? []
+    : block.reduce((acc, line) => {
+      const match = ENTRY_PATTERN.exec(line);
+      if (match) {
+        acc.push({root, key: match[1], type: match[2], value: match[3] || ''});
+      }
+      return acc;
+    }, []);
+}
+
+function parseRegQueryOutput (output) {
+  const result = [];
+  let root;
+  let regEntriesBlock = [];
+  for (const line of output.split('\n').map(_.trimEnd)) {
+    if (!_.trim(line)) {
+      continue;
+    }
+
+    const curIndent = line.length - _.trimStart(line).length;
+    if (curIndent === 0) {
+      result.push(...parseRegEntries(root, regEntriesBlock));
+      root = line;
+      regEntriesBlock = [];
+    } else {
+      regEntriesBlock.push(line);
+    }
+  }
+  result.push(...parseRegEntries(root, regEntriesBlock));
+  return result;
+}
+
+/**
+ * @typedef Object RegEntry
+ * @property {string} root Full path to the registry branch, for example
+ * HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\DirectDrawEx
+ * @property {string} key The registry key name
+ * @property {string} type One of possible registry value types, for example
+ * REG_DWORD or REG_SZ
+ * @property {string} value The actual value. Could be empty
+ */
+
+/**
+ * Lists registry tree (e.g. recursively) under the given root node.
+ * The lookup is done under the same registry branch that the current process
+ * system architecture.
+ *
+ * @param {string} root The registry key name, which consists of tro parts:
+ * - The root key: HKLM | HKCU | HKCR | HKU | HKCC
+ * - The subkey under the selected root key, for example \Software\Microsoft
+ * @returns {RegEntry[]} List of matched RegEntry instances or an empty list
+ * if either no entries were found under the given root or the root does not exist.
+ */
+async function queryRegistry (root) {
+  let stdout;
+  try {
+    ({stdout} = await exec(REG, ['query', root, '/s']));
+  } catch (e) {
+    return [];
+  }
+  return parseRegQueryOutput(stdout);
+}
+
+export { queryRegistry, parseRegQueryOutput };

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -21,7 +21,7 @@ function parseRegQueryOutput (output) {
   let root;
   let regEntriesBlock = [];
   for (const line of output.split('\n').map(_.trimEnd)) {
-    if (!_.trim(line)) {
+    if (!line) {
       continue;
     }
 

--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { JWProxy, errors } from 'appium-base-driver';
 import log from './logger';
 import { SubProcess } from 'teen_process';
-import { getWADExecutablePath, isWADChecksumOk } from './installer';
+import { getWADExecutablePath } from './installer';
 import { waitForCondition } from 'asyncbox';
 import { execSync } from 'child_process';
 import { util } from 'appium-support';
@@ -117,9 +117,6 @@ class WinAppDriver {
 
   async start (caps) {
     const executablePath = await getWADExecutablePath();
-    if (!await isWADChecksumOk(executablePath)) {
-      log.warn('WinAppDriver exists, but the checksum did not match. Was it replaced manually?');
-    }
 
     this.process = new WADProcess({
       // XXXYD TODO: would be better if WinAppDriver didn't require passing in /wd/hub as a param

--- a/test/unit/registry-specs.js
+++ b/test/unit/registry-specs.js
@@ -1,0 +1,106 @@
+import { parseRegQueryOutput } from '../../lib/registry';
+import chai from 'chai';
+
+chai.should();
+
+describe('registry', function () {
+  it('should parse reg query output', function () {
+    const output = `
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\AddressBook
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Connection Manager
+    SystemComponent    REG_DWORD    0x1
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\DirectDrawEx
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\DXM_Runtime
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Fontcore
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\IE40
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\IE4Data
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\IE5BAKEX
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\IEData
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\MobileOptionPack
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\MPlayer2
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\SchedulingAgent
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WIC
+    NoRemove    REG_DWORD    0x1
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{12B6D916-FD64-471C-8EF7-C04443A75F8D}
+    AuthorizedCDFPrefix    REG_SZ
+    Comments    REG_SZ
+    Contact    REG_SZ
+    DisplayVersion    REG_SZ    40.28.30105
+    HelpLink    REG_SZ
+    HelpTelephone    REG_SZ
+    InstallDate    REG_SZ    20211019
+    InstallLocation    REG_SZ
+    InstallSource    REG_SZ    C:\\ProgramData\\Package Cache\\{12B6D916-FD64-471C-8EF7-C04443A75F8D}v40.28.30105\\
+    ModifyPath    REG_EXPAND_SZ    MsiExec.exe /X{12B6D916-FD64-471C-8EF7-C04443A75F8D}
+    NoModify    REG_DWORD    0x1
+    Publisher    REG_SZ    Microsoft Corporation
+    Readme    REG_SZ
+    Size    REG_SZ
+    EstimatedSize    REG_DWORD    0x16c
+    SystemComponent    REG_DWORD    0x1
+    UninstallString    REG_EXPAND_SZ    MsiExec.exe /X{12B6D916-FD64-471C-8EF7-C04443A75F8D}
+    URLInfoAbout    REG_SZ
+    URLUpdateInfo    REG_SZ
+    VersionMajor    REG_DWORD    0x28
+    VersionMinor    REG_DWORD    0x1c
+    WindowsInstaller    REG_DWORD    0x1
+    Version    REG_DWORD    0x281c7599
+    Language    REG_DWORD    0x409
+    DisplayName    REG_SZ    Microsoft .NET Host - 5.0.7 (x64)
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{29DA7679-80B6-452A-B264-349BAEE7CC0E}
+    AuthorizedCDFPrefix    REG_SZ
+    Comments    REG_SZ
+    Contact    REG_SZ
+    DisplayVersion    REG_SZ    1.2.99.0
+    HelpLink    REG_SZ
+    HelpTelephone    REG_SZ
+    InstallDate    REG_SZ    20211019
+    InstallLocation    REG_SZ
+    InstallSource    REG_SZ    C:\\ProgramData\\Package Cache\\{29DA7679-80B6-452A-B264-349BAEE7CC0E}v1.2.99.0\\
+    ModifyPath    REG_EXPAND_SZ    MsiExec.exe /I{29DA7679-80B6-452A-B264-349BAEE7CC0E}
+    Publisher    REG_SZ    Microsoft Corporation
+    Readme    REG_SZ
+    Size    REG_SZ
+    EstimatedSize    REG_DWORD    0x6fd8
+    SystemComponent    REG_DWORD    0x1
+    UninstallString    REG_EXPAND_SZ    MsiExec.exe /I{29DA7679-80B6-452A-B264-349BAEE7CC0E}
+    URLInfoAbout    REG_SZ
+    URLUpdateInfo    REG_SZ
+    VersionMajor    REG_DWORD    0x1
+    VersionMinor    REG_DWORD    0x2
+    WindowsInstaller    REG_DWORD    0x1
+    Version    REG_DWORD    0x1020063
+    Language    REG_DWORD    0x409
+    DisplayName    REG_SZ    Windows Application Driver
+
+    `;
+    const result = parseRegQueryOutput(output);
+    Boolean(result.find(
+      ({root, key, type, value}) => root === 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{29DA7679-80B6-452A-B264-349BAEE7CC0E}'
+        && key === 'DisplayName' && type === 'REG_SZ' && value === 'Windows Application Driver'
+    )).should.be.true;
+  });
+  it('should return empty array if no matches found', function () {
+    const output = `
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\AddressBook
+
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\DirectDrawEx
+    `;
+    const result = parseRegQueryOutput(output);
+    result.length.should.be.eql(0);
+  });
+});


### PR DESCRIPTION
https://github.com/microsoft/WinAppDriver/releases/tag/v1.2.99

This build also got an updated install script, which allows to actually uninstall WAD. The script is now is distributed for multiple architectures and has `.exe` extension instead of `.msi`