### PR TITLE
fix: Properly set base path for the proxy

### DIFF
--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -11,7 +11,7 @@ import { util } from '@appium/support';
 import { findAPortNotInUse } from 'portscanner';
 
 
-const DEFAULT_BASE = '/wd/hub';
+const DEFAULT_BASE_PATH = '/wd/hub';
 const DEFAULT_HOST = '127.0.0.1';
 const WAD_PORT_RANGE = [4724, 4824];
 const STARTUP_TIMEOUT_MS = 10000;
@@ -120,13 +120,14 @@ class WinAppDriver {
 
     this.process = new WADProcess({
       // XXXYD TODO: would be better if WinAppDriver didn't require passing in /wd/hub as a param
-      base: DEFAULT_BASE,
+      base: DEFAULT_BASE_PATH,
       port: this.proxyPort,
       executablePath,
     });
     await this.process.start();
 
     this.proxy = new WADProxy({
+      base: this.process.base,
       server: DEFAULT_HOST,
       port: this.process.port,
     });


### PR DESCRIPTION
The default base path in Appium 2 proxy is `/`, while WAD sets the one to `/wd/hub`. I've updated the logic to properly align them