### PR TITLE
feat: add "tag name" support in the locator

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -35,6 +35,7 @@ class WindowsDriver extends BaseDriver {
       'xpath',
       'id',
       'name',
+      'tag name',
       'class name',
       'accessibility id',
     ];


### PR DESCRIPTION
https://github.com/appium/appium/issues/17577
Actually current appium-windows-driver does not have `tag name`
(https://github.com/microsoft/WinAppDriver/blob/master/Tests/WebDriverAPI/Element.cs has test code to use the tag name locator)