### PR TITLE
Added support for keyboard/mouse on Actions

### DIFF
--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -4,36 +4,36 @@ commands.performActions = async function (actions) {
   switch (actions[0].id) {
     case 'default keyboard':
       this.log.info('Mapping keyboard actions');
-      return await performKeyboardCommands(this.winAppDriver, actions[0].actions);
+      return await performKeyboardCommands.bind(this)(actions[0].actions);
     case 'default mouse':
       this.log.info('Mapping mouse actions');
-      return await performMouseCommands(this.winAppDriver, actions[0].actions, this.log);
+      return await performMouseCommands.bind(this)(actions[0].actions);
     default:
       this.log.info('Going default actions route');
       return await this.winAppDriver.sendCommand('/actions', 'POST', {actions});
   };
 };
 
-async function performKeyboardCommands(winAppDriver, actions) {
+async function performKeyboardCommands(actions) {
   const keysFormatted = formatKeyboardInput(actions);
-  return await winAppDriver.sendCommand('/keys', 'POST', {'value': keysFormatted });
+  return await this.winAppDriver.sendCommand('/keys', 'POST', {'value': keysFormatted });
 }
 
-async function performMouseCommands(winAppDriver, actions, log) {
+async function performMouseCommands(actions) {
   let result;
   for (const action in actions) {
     switch (actions[action].type) {
       case 'pointerMove':
-        result = await winAppDriver.sendCommand('/moveto', 'POST', {'element': actions[action].origin.ELEMENT });
+        result = await this.winAppDriver.sendCommand('/moveto', 'POST', {'element': actions[action].origin.ELEMENT });
         break;
       case 'pointerDown':
-        result = await winAppDriver.sendCommand('/buttondown', 'POST', {'button': actions[action].button });
+        result = await this.winAppDriver.sendCommand('/buttondown', 'POST', {'button': actions[action].button });
         break;
       case 'pointerUp':
-        result = await winAppDriver.sendCommand('/buttonup', 'POST', {'button': actions[action].button });
+        result = await this.winAppDriver.sendCommand('/buttonup', 'POST', {'button': actions[action].button });
         break;
       default:
-        log.info('No mouse action mapped for type: ' + JSON.stringify(actions[action].type) + ' Moving to next action');
+        this.log.info('No mouse action mapped for type: ' + JSON.stringify(actions[action].type) + ' Moving to next action');
     }
   };
   return result;

--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -21,16 +21,16 @@ async function performKeyboardCommands(winAppDriver, actions) {
 
 async function performMouseCommands(winAppDriver, actions, log) {
   let result;
-  for (let action in actions) {
+  for (const action in actions) {
     switch (actions[action].type) {
       case 'pointerMove':
         result = await winAppDriver.sendCommand('/moveto', 'POST', {'element': actions[action].origin.ELEMENT });
         break;
       case 'pointerDown':
-        result = await winAppDriver.sendCommand('/buttondown', 'POST', {});
+        result = await winAppDriver.sendCommand('/buttondown', 'POST', {'button': actions[action].button });
         break;
       case 'pointerUp':
-        result = await winAppDriver.sendCommand('/buttonup', 'POST', {});
+        result = await winAppDriver.sendCommand('/buttonup', 'POST', {'button': actions[action].button });
         break;
       default:
         log.info('No mouse action mapped for type: ' + JSON.stringify(actions[action].type) + ' Moving to next action');
@@ -40,11 +40,13 @@ async function performMouseCommands(winAppDriver, actions, log) {
 }
 
 function formatKeyboardInput(actions) {
-  const keys = new Set();
+  const keys = new Array();
   actions.forEach((action) => {
-    keys.add(action.value);
+    if (action.type === 'keyDown') {
+      keys.push(action.value);
+    }
   });
-  return [Array.from(keys).join('')];
+  return [keys.join('')];
 }
 
 Object.assign(commands);

--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -1,30 +1,65 @@
+import { util } from 'appium/support';
+
 const commands = {};
+const { promisify } = require('util');
+const sleep = promisify(setTimeout);
+
 //This is needed to make clicks on -image elements work properly
 commands.performActions = async function (actions) {
-  switch (actions[0].id) {
-    case 'default keyboard':
+  //Workaround for https://github.com/appium/appium/issues/16268
+  //Once WAD offers full W3C support for keyboard and mouse type pointer actions, this can be proxied directly to the /actions endpoint
+  for (const command in actions) {
+    if (actions[command].type === 'key') {
       this.log.info('Mapping keyboard actions');
-      return await performKeyboardCommands.bind(this)(actions[0].actions);
-    case 'default mouse':
+      return await performKeyboardCommands.bind(this)(actions[command].actions);
+    } else if (actions[command].type === 'pointer' && actions[command].parameters.pointerType === 'mouse') {
       this.log.info('Mapping mouse actions');
-      return await performMouseCommands.bind(this)(actions[0].actions);
-    default:
+      return await performMouseCommands.bind(this)(actions[command].actions);
+    } else {
       this.log.info('Going default actions route');
       return await this.winAppDriver.sendCommand('/actions', 'POST', {actions});
-  };
+    }
+  }
 };
 
+/*
+  Supported actions:
+  -> sendKeys(CharSequence... keys)
+  -> sendKeysInTicks(CharSequence... keys)
+*/
+// TODO: remove once WAD offers W3C for keyboard input actions
 async function performKeyboardCommands(actions) {
   const keysFormatted = formatKeyboardInput(actions);
   return await this.winAppDriver.sendCommand('/keys', 'POST', {'value': keysFormatted });
 }
 
+/*
+  Supported actions:
+  -> click()
+  -> click(WebElement target)
+  -> contextClick()
+  -> contextClick(WebElement target)
+  -> release()
+  -> release(WebElement target)
+  -> clickAndHold()
+  -> clickAndHold(WebElement target)
+  -> doubleClick()
+  -> doubleClick(WebElement target)
+  -> moveToElement(WebElement target)
+  -> moveToElement(WebElement target, int xOffset, int yOffset)
+  -> dragAndDrop(WebElement source, WebElement target)
+  -> pause()
+
+*/
+// TODO: remove once WAD offers W3C support for pointer actions of type mouse
 async function performMouseCommands(actions) {
   let result;
   for (const action in actions) {
     switch (actions[action].type) {
       case 'pointerMove':
-        result = await this.winAppDriver.sendCommand('/moveto', 'POST', {'element': actions[action].origin.ELEMENT });
+        this.log.info(JSON.stringify(actions[action]));
+        this.log.info('Done');
+        result = await this.winAppDriver.sendCommand('/moveto', 'POST', getExpectedFormatForMouseMovement(actions[action]));
         break;
       case 'pointerDown':
         result = await this.winAppDriver.sendCommand('/buttondown', 'POST', {'button': actions[action].button });
@@ -32,8 +67,11 @@ async function performMouseCommands(actions) {
       case 'pointerUp':
         result = await this.winAppDriver.sendCommand('/buttonup', 'POST', {'button': actions[action].button });
         break;
+      case 'pause':
+        await sleep(actions[action].duration);
+        break;
       default:
-        this.log.info('No mouse action mapped for type: ' + JSON.stringify(actions[action].type) + ' Moving to next action');
+        this.log.info('No mouse action mapped for type: ${JSON.stringify(actions[action].type)}, moving to next action');
     }
   };
   return result;
@@ -47,6 +85,14 @@ function formatKeyboardInput(actions) {
     }
   });
   return [keys.join('')];
+}
+
+function getExpectedFormatForMouseMovement(action) {
+  const elementId = util.unwrapElement(action.origin);
+  if (action.x !== 0 && action.y !== 0) {
+    return { 'yoffset': action.y, 'xoffset': action.x, 'element': elementId };
+  }
+  return { 'element': elementId };
 }
 
 Object.assign(commands);

--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -1,14 +1,51 @@
 const commands = {};
-const fs = require('fs');
 //This is needed to make clicks on -image elements work properly
 commands.performActions = async function (actions) {
-  fs.writeFile('C:/logs/log.txt', actions, err => {
-    if (err) {
-      console.error(err);
-    }
-  });
-  return await this.winAppDriver.sendCommand('/actions', 'POST', {actions});
+  switch (actions[0].id) {
+    case 'default keyboard':
+      this.log.info('Mapping keyboard actions');
+      return await performKeyboardCommands(this.winAppDriver, actions[0].actions);
+    case 'default mouse':
+      this.log.info('Mapping mouse actions');
+      return await performMouseCommands(this.winAppDriver, actions[0].actions, this.log);
+    default:
+      this.log.info('Going default actions route');
+      return await this.winAppDriver.sendCommand('/actions', 'POST', {actions});
+  };
 };
+
+async function performKeyboardCommands(winAppDriver, actions) {
+  const keysFormatted = formatKeyboardInput(actions);
+  return await winAppDriver.sendCommand('/keys', 'POST', {'value': keysFormatted });
+}
+
+async function performMouseCommands(winAppDriver, actions, log) {
+  let result;
+  for (let action in actions) {
+    switch (actions[action].type) {
+      case 'pointerMove':
+        result = await winAppDriver.sendCommand('/moveto', 'POST', {'element': actions[action].origin.ELEMENT });
+        break;
+      case 'pointerDown':
+        result = await winAppDriver.sendCommand('/buttondown', 'POST', {});
+        break;
+      case 'pointerUp':
+        result = await winAppDriver.sendCommand('/buttonup', 'POST', {});
+        break;
+      default:
+        log.info('No mouse action mapped for type: ' + JSON.stringify(actions[action].type) + ' Moving to next action');
+    }
+  };
+  return result;
+}
+
+function formatKeyboardInput(actions) {
+  const keys = new Set();
+  actions.forEach((action) => {
+    keys.add(action.value);
+  });
+  return [Array.from(keys).join('')];
+}
 
 Object.assign(commands);
 export default commands;

--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -1,7 +1,12 @@
 const commands = {};
-
+const fs = require('fs');
 //This is needed to make clicks on -image elements work properly
 commands.performActions = async function (actions) {
+  fs.writeFile('C:/logs/log.txt', actions, err => {
+    if (err) {
+      console.error(err);
+    }
+  });
   return await this.winAppDriver.sendCommand('/actions', 'POST', {actions});
 };
 

--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -1,8 +1,7 @@
 import { util } from 'appium/support';
+import { Promise } from 'bluebird';
 
 const commands = {};
-const { promisify } = require('util');
-const sleep = promisify(setTimeout);
 
 //This is needed to make clicks on -image elements work properly
 commands.performActions = async function (actions) {
@@ -57,18 +56,16 @@ async function performMouseCommands(actions) {
   for (const action in actions) {
     switch (actions[action].type) {
       case 'pointerMove':
-        this.log.info(JSON.stringify(actions[action]));
-        this.log.info('Done');
         result = await this.winAppDriver.sendCommand('/moveto', 'POST', getExpectedFormatForMouseMovement(actions[action]));
         break;
       case 'pointerDown':
-        result = await this.winAppDriver.sendCommand('/buttondown', 'POST', {'button': actions[action].button });
+        result = await this.winAppDriver.sendCommand('/buttondown', 'POST', {'button': actions[action].button ?? 0 });
         break;
       case 'pointerUp':
-        result = await this.winAppDriver.sendCommand('/buttonup', 'POST', {'button': actions[action].button });
+        result = await this.winAppDriver.sendCommand('/buttonup', 'POST', {'button': actions[action].button ?? 0 });
         break;
       case 'pause':
-        await sleep(actions[action].duration);
+        await Promise.delay(500);
         break;
       default:
         this.log.info('No mouse action mapped for type: ${JSON.stringify(actions[action].type)}, moving to next action');

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -21,10 +21,12 @@ const NO_PROXY = [
   // Workarounds for
   // - https://github.com/appium/appium/issues/15923
   // - https://github.com/appium/appium/issues/16316
+  // - https://github.com/appium/appium/issues/16268
   // TODO: Remove it after WAD properly supports W3C
   ['GET', new RegExp('^/session/[^/]+/element/[^/]+/rect')],
   ['POST', new RegExp('^/session/[^/]+/window/rect')],
   ['GET', new RegExp('^/session/[^/]+/window/rect')],
+  ['POST', new RegExp('^/session/[^/]+/actions')],
   // end workaround
 ];
 


### PR DESCRIPTION
The Mouse and Keyboard interface are deprecated under latest appium version
Actions done under those interfaces are now under the Actions umbrella but winappDriver had no support for it.

Redirected the actions to the right endpoints from the winAppDriver

Not sure If I mapped all the actions under the Mouse interface (I mainly needed support for actions under the drag&drop methods umbrella. Should be easy to map new endpoints if I missed something)

