### PR TITLE
fix: release package

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
     "lib",
     "build/index.js",
     "build/install-npm.js",
-    "build/lib"
+    "build/lib",
+    "CHANGELOG.md",
+    "LICENSE",
+    "npm-shrinkwrap.json"
   ],
   "dependencies": {
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
To include `npm-shrinkwrap.json` in the release package as same as before.
https://github.com/appium/appium-xcuitest-driver/pull/2023