### PR TITLE
chore: Avoid throwing generic error for an unknown execute script name

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -22,7 +22,7 @@ export async function execute (script, args) {
   this.log.info(`Executing extension command '${script}'`);
   const formattedScript = _.isString(script)
     ? script.trim().replace(/^windows:\s*/, `${EXECUTE_SCRIPT_PREFIX} `)
-    : '';
+    : String(script);
   const preprocessedArgs = preprocessExecuteMethodArgs(args);
   return await this.executeMethod(formattedScript, [preprocessedArgs]);
 }

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { errors } from 'appium/driver';
 import { POWER_SHELL_FEATURE } from '../constants';
 
 const POWER_SHELL_SCRIPT = 'powerShell';
@@ -13,18 +12,19 @@ const EXECUTE_SCRIPT_PREFIX = 'windows:';
  * @returns {Promise<any>}
  */
 export async function execute (script, args) {
-  if (_.startsWith(script, EXECUTE_SCRIPT_PREFIX)) {
-    this.log.info(`Executing extension command '${script}'`);
-    const formattedScript = script.trim().replace(/^windows:\s*/, `${EXECUTE_SCRIPT_PREFIX} `);
-    const preprocessedArgs = preprocessExecuteMethodArgs(args);
-    return await this.executeMethod(formattedScript, [preprocessedArgs]);
-  } else if (script === POWER_SHELL_SCRIPT) {
+  if (script === POWER_SHELL_SCRIPT) {
     this.assertFeatureEnabled(POWER_SHELL_FEATURE);
     return await this.execPowerShell(
       /** @type {import('./powershell').ExecPowerShellOptions} */ (preprocessExecuteMethodArgs(args))
     );
   }
-  throw new errors.NotImplementedError();
+
+  this.log.info(`Executing extension command '${script}'`);
+  const formattedScript = _.isString(script)
+    ? script.trim().replace(/^windows:\s*/, `${EXECUTE_SCRIPT_PREFIX} `)
+    : '';
+  const preprocessedArgs = preprocessExecuteMethodArgs(args);
+  return await this.executeMethod(formattedScript, [preprocessedArgs]);
 }
 
 /**


### PR DESCRIPTION
Inspired by https://github.com/appium/appium-mac2-driver/pull/327#discussion_r1939668545