### PR TITLE
fix: Delete screen recording after serving.

### DIFF
--- a/lib/commands/record-screen.js
+++ b/lib/commands/record-screen.js
@@ -321,18 +321,23 @@ export async function stopRecordingScreen (
     this.log.debug('No video data is found. Returning an empty string');
     return '';
   }
-  if (_.isEmpty(remotePath)) {
-    const {size} = await fs.stat(videoPath);
-    this.log.debug(`The size of the resulting screen recording is ${util.toReadableSizeString(size)}`);
+
+  try {
+    if (_.isEmpty(remotePath)) {
+      const {size} = await fs.stat(videoPath);
+      this.log.debug(`The size of the resulting screen recording is ${util.toReadableSizeString(size)}`);
+    }
+    return await uploadRecordedMedia(videoPath, remotePath, {
+      user,
+      pass,
+      method,
+      headers,
+      fileFieldName,
+      formFields,
+    });
+  } finally {
+    await fs.rimraf(videoPath);
   }
-  return await uploadRecordedMedia(videoPath, remotePath, {
-    user,
-    pass,
-    method,
-    headers,
-    fileFieldName,
-    formFields,
-  });
 }
 
 /**


### PR DESCRIPTION
It seems that the video file deletion was missed when the screen recording was properly terminated.