### PR TITLE
fix: Clearing previous recorded video if start new one.

### DIFF
--- a/lib/commands/record-screen.js
+++ b/lib/commands/record-screen.js
@@ -253,7 +253,7 @@ export async function startRecordingScreen (
     this.log.debug('Forcing the active screen recording to stop');
     await this._screenRecorder.stop(true);
   } else if (this._screenRecorder) {
-    this.log.debug('Clearing previous record');
+    this.log.debug('Clearing the recent screen recording');
     await this._screenRecorder.stop(true);
   }
   this._screenRecorder = null;

--- a/lib/commands/record-screen.js
+++ b/lib/commands/record-screen.js
@@ -252,6 +252,9 @@ export async function startRecordingScreen (
     }
     this.log.debug('Forcing the active screen recording to stop');
     await this._screenRecorder.stop(true);
+  } else if (this._screenRecorder) {
+    this.log.debug('Clearing previous record');
+    await this._screenRecorder.stop(true);
   }
   this._screenRecorder = null;
 


### PR DESCRIPTION
when recording screen multiple times, only the last recorded file gets deleted, while the previously recorded files all remain in the temporary directory.