### PR TITLE
fix: executeMethodMap of startRecordingScreen

### DIFF
--- a/lib/commands/record-screen.js
+++ b/lib/commands/record-screen.js
@@ -401,7 +401,7 @@ export async function stopRecordingScreen(options = {}) {
 
 /**
  * For detailed explanations of each property,
- * please refer to the parameters of the `windowsStartRecordingScreen` function.
+ * please refer to the parameters of the {@linkcode windowsStartRecordingScreen} function.
  *
  * @typedef {Object} StartRecordingOptions
  *
@@ -417,7 +417,7 @@ export async function stopRecordingScreen(options = {}) {
 
 /**
  * For detailed explanations of each property,
- * please refer to the parameters of the `windowsStopRecordingScreen` function.
+ * please refer to the parameters of the {@linkcode windowsStopRecordingScreen} function.
  *
  * @typedef {Object} StopRecordingOptions
  *

--- a/lib/commands/record-screen.js
+++ b/lib/commands/record-screen.js
@@ -402,7 +402,7 @@ export async function stopRecordingScreen(options = {}) {
 /**
  * For detailed explanations of each property,
  * please refer to the parameters of the `windowsStartRecordingScreen` function.
- * 
+ *
  * @typedef {Object} StartRecordingOptions
  *
  * @property {string} [videoFilter]
@@ -418,7 +418,7 @@ export async function stopRecordingScreen(options = {}) {
 /**
  * For detailed explanations of each property,
  * please refer to the parameters of the `windowsStopRecordingScreen` function.
- * 
+ *
  * @typedef {Object} StopRecordingOptions
  *
  * @property {string} [remotePath]

--- a/lib/commands/record-screen.js
+++ b/lib/commands/record-screen.js
@@ -234,7 +234,7 @@ export class ScreenRecorder {
  * (`false`) or to start a new recording immediately and terminate the existing one if running (`true`).
  * @throws {Error} If screen recording has failed to start or is not supported on the device under test.
  */
-export async function startRecordingScreen (
+export async function windowsStartRecordingScreen (
   timeLimit,
   videoFilter,
   fps,
@@ -301,7 +301,7 @@ export async function startRecordingScreen (
  * or the file content cannot be uploaded to the remote location
  * or screen recording is not supported on the device under test.
  */
-export async function stopRecordingScreen (
+export async function windowsStopRecordingScreen (
   remotePath,
   user,
   pass,
@@ -333,6 +333,120 @@ export async function stopRecordingScreen (
     fileFieldName,
     formFields,
   });
+}
+
+/**
+ * @typedef {Object} StartRecordingOptions
+ *
+ * @property {string} videoFilter - The video filter spec to apply for ffmpeg.
+ * See https://trac.ffmpeg.org/wiki/FilteringGuide for more details on the possible values.
+ * Example: Set it to `scale=ifnot(gte(iw\,1024)\,iw\,1024):-2` in order to limit the video width
+ * to 1024px. The height will be adjusted automatically to match the actual ratio.
+ * @property {number|string} fps [15] - The count of frames per second in the resulting video.
+ * The greater fps it has the bigger file size is.
+ * @property {string} preset [veryfast] - One of the supported encoding presets. Possible values are:
+ * - ultrafast
+ * - superfast
+ * - veryfast
+ * - faster
+ * - fast
+ * - medium
+ * - slow
+ * - slower
+ * - veryslow
+ * A preset is a collection of options that will provide a certain encoding speed to compression ratio.
+ * A slower preset will provide better compression (compression is quality per filesize).
+ * This means that, for example, if you target a certain file size or constant bit rate, you will achieve better
+ * quality with a slower preset. Read https://trac.ffmpeg.org/wiki/Encode/H.264 for more details.
+ * @property {boolean} captureCursor [false] - Whether to capture the mouse cursor while recording
+ * the screen
+ * @property {boolean} captureClicks [false] - Whether to capture mouse clicks while recording the
+ * screen
+ * @property {string} audioInput - If set then the given audio input will be used to record the computer audio
+ * along with the desktop video. The list of available devices could be retrieved using
+ * `ffmpeg -list_devices true -f dshow -i dummy` command.
+ * @property {string|number} timeLimit [600] - The maximum recording time, in seconds. The default
+ * value is 600 seconds (10 minutes).
+ * @property {boolean} forceRestart [true] - Whether to ignore the call if a screen recording is currently running
+ * (`false`) or to start a new recording immediately and terminate the existing one if running (`true`).
+ */
+
+/**
+ * Record the display in background while the automated test is running.
+ * This method requires FFMPEG (https://www.ffmpeg.org/download.html) to be installed
+ * and present in PATH.
+ * The resulting video uses H264 codec and is ready to be played by media players built-in into web browsers.
+ *
+ * @param {StartRecordingOptions} options - The available options.
+ * @this {import('../driver').WindowsDriver}
+ * @throws {Error} If screen recording has failed to start or is not supported on the device under test.
+ */
+export async function startRecordingScreen(options) {
+  const {
+    timeLimit,
+    videoFilter,
+    fps,
+    preset,
+    captureCursor,
+    captureClicks,
+    audioInput,
+    forceRestart = true,
+  } = options ?? {};
+
+  await this.windowsStartRecordingScreen(
+    timeLimit,
+    videoFilter,
+    fps,
+    preset,
+    captureCursor,
+    captureClicks,
+    audioInput,
+    forceRestart
+  );
+}
+
+/**
+ * @typedef {Object} StopRecordingOptions
+ *
+ * @property {string} remotePath - The path to the remote location, where the resulting video should be uploaded.
+ * The following protocols are supported: http/https, ftp.
+ * Null or empty string value (the default setting) means the content of resulting
+ * file should be encoded as Base64 and passed as the endpoint response value.
+ * An exception will be thrown if the generated media file is too big to
+ * fit into the available process memory.
+ * @property {string} user - The name of the user for the remote authentication.
+ * @property {string} pass - The password for the remote authentication.
+ * @property {string} method - The http multipart upload method name. The 'PUT' one is used by default.
+ * @property {Object} headers - Additional headers mapping for multipart http(s) uploads
+ * @property {string} fileFieldName [file] - The name of the form field, where the file content BLOB should be stored for
+ *                                            http(s) uploads
+ * @property {Object[]|[string, string][]} formFields - Additional form fields for multipart http(s) uploads
+ */
+
+/**
+ * Stop recording the screen.
+ * If no screen recording has been started before then the method returns an empty string.
+ *
+ * @param {StopRecordingOptions} options - The available options.
+ * @returns {Promise<string>} Base64-encoded content of the recorded media file if 'remotePath'
+ * parameter is falsy or an empty string.
+ * @this {import('../driver').WindowsDriver}
+ * @throws {Error} If there was an error while getting the name of a media file
+ * or the file content cannot be uploaded to the remote location
+ * or screen recording is not supported on the device under test.
+ */
+export async function stopRecordingScreen(options) {
+  const {remotePath, user, pass, method, headers, fileFieldName, formFields} = options ?? {};
+
+  return await this.windowsStopRecordingScreen(
+    remotePath,
+    user,
+    pass,
+    method,
+    headers,
+    fileFieldName,
+    formFields
+  );
 }
 
 /**

--- a/lib/commands/record-screen.js
+++ b/lib/commands/record-screen.js
@@ -336,52 +336,16 @@ export async function windowsStopRecordingScreen (
 }
 
 /**
- * @typedef {Object} StartRecordingOptions
- *
- * @property {string} videoFilter - The video filter spec to apply for ffmpeg.
- * See https://trac.ffmpeg.org/wiki/FilteringGuide for more details on the possible values.
- * Example: Set it to `scale=ifnot(gte(iw\,1024)\,iw\,1024):-2` in order to limit the video width
- * to 1024px. The height will be adjusted automatically to match the actual ratio.
- * @property {number|string} fps [15] - The count of frames per second in the resulting video.
- * The greater fps it has the bigger file size is.
- * @property {string} preset [veryfast] - One of the supported encoding presets. Possible values are:
- * - ultrafast
- * - superfast
- * - veryfast
- * - faster
- * - fast
- * - medium
- * - slow
- * - slower
- * - veryslow
- * A preset is a collection of options that will provide a certain encoding speed to compression ratio.
- * A slower preset will provide better compression (compression is quality per filesize).
- * This means that, for example, if you target a certain file size or constant bit rate, you will achieve better
- * quality with a slower preset. Read https://trac.ffmpeg.org/wiki/Encode/H.264 for more details.
- * @property {boolean} captureCursor [false] - Whether to capture the mouse cursor while recording
- * the screen
- * @property {boolean} captureClicks [false] - Whether to capture mouse clicks while recording the
- * screen
- * @property {string} audioInput - If set then the given audio input will be used to record the computer audio
- * along with the desktop video. The list of available devices could be retrieved using
- * `ffmpeg -list_devices true -f dshow -i dummy` command.
- * @property {string|number} timeLimit [600] - The maximum recording time, in seconds. The default
- * value is 600 seconds (10 minutes).
- * @property {boolean} forceRestart [true] - Whether to ignore the call if a screen recording is currently running
- * (`false`) or to start a new recording immediately and terminate the existing one if running (`true`).
- */
-
-/**
  * Record the display in background while the automated test is running.
  * This method requires FFMPEG (https://www.ffmpeg.org/download.html) to be installed
  * and present in PATH.
  * The resulting video uses H264 codec and is ready to be played by media players built-in into web browsers.
  *
- * @param {StartRecordingOptions} options - The available options.
+ * @param {StartRecordingOptions} [options] - The available options.
  * @this {import('../driver').WindowsDriver}
  * @throws {Error} If screen recording has failed to start or is not supported on the device under test.
  */
-export async function startRecordingScreen(options) {
+export async function startRecordingScreen(options = {}) {
   const {
     timeLimit,
     videoFilter,
@@ -391,7 +355,7 @@ export async function startRecordingScreen(options) {
     captureClicks,
     audioInput,
     forceRestart = true,
-  } = options ?? {};
+  } = options;
 
   await this.windowsStartRecordingScreen(
     timeLimit,
@@ -406,28 +370,10 @@ export async function startRecordingScreen(options) {
 }
 
 /**
- * @typedef {Object} StopRecordingOptions
- *
- * @property {string} remotePath - The path to the remote location, where the resulting video should be uploaded.
- * The following protocols are supported: http/https, ftp.
- * Null or empty string value (the default setting) means the content of resulting
- * file should be encoded as Base64 and passed as the endpoint response value.
- * An exception will be thrown if the generated media file is too big to
- * fit into the available process memory.
- * @property {string} user - The name of the user for the remote authentication.
- * @property {string} pass - The password for the remote authentication.
- * @property {string} method - The http multipart upload method name. The 'PUT' one is used by default.
- * @property {Object} headers - Additional headers mapping for multipart http(s) uploads
- * @property {string} fileFieldName [file] - The name of the form field, where the file content BLOB should be stored for
- *                                            http(s) uploads
- * @property {Object[]|[string, string][]} formFields - Additional form fields for multipart http(s) uploads
- */
-
-/**
  * Stop recording the screen.
  * If no screen recording has been started before then the method returns an empty string.
  *
- * @param {StopRecordingOptions} options - The available options.
+ * @param {StopRecordingOptions} [options] - The available options.
  * @returns {Promise<string>} Base64-encoded content of the recorded media file if 'remotePath'
  * parameter is falsy or an empty string.
  * @this {import('../driver').WindowsDriver}
@@ -435,8 +381,8 @@ export async function startRecordingScreen(options) {
  * or the file content cannot be uploaded to the remote location
  * or screen recording is not supported on the device under test.
  */
-export async function stopRecordingScreen(options) {
-  const {remotePath, user, pass, method, headers, fileFieldName, formFields} = options ?? {};
+export async function stopRecordingScreen(options = {}) {
+  const {remotePath, user, pass, method, headers, fileFieldName, formFields} = options;
 
   return await this.windowsStopRecordingScreen(
     remotePath,
@@ -451,4 +397,35 @@ export async function stopRecordingScreen(options) {
 
 /**
  * @typedef {import('../driver').WindowsDriver} WindowsDriver
+ */
+
+/**
+ * For detailed explanations of each property,
+ * please refer to the parameters of the `windowsStartRecordingScreen` function.
+ * 
+ * @typedef {Object} StartRecordingOptions
+ *
+ * @property {string} [videoFilter]
+ * @property {number|string} [fps=15]
+ * @property {string} [preset='veryfast']
+ * @property {boolean} [captureCursor=false]
+ * @property {boolean} [captureClicks=false]
+ * @property {string} [audioInput]
+ * @property {string|number} [timeLimit=600]
+ * @property {boolean} [forceRestart=true]
+ */
+
+/**
+ * For detailed explanations of each property,
+ * please refer to the parameters of the `windowsStopRecordingScreen` function.
+ * 
+ * @typedef {Object} StopRecordingOptions
+ *
+ * @property {string} [remotePath]
+ * @property {string} [user]
+ * @property {string} [pass]
+ * @property {string} [method]
+ * @property {Object} [headers]
+ * @property {string} [fileFieldName='file']
+ * @property {Object[]|[string, string][]} [formFields]
  */

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -204,6 +204,8 @@ export class WindowsDriver extends BaseDriver {
 
   execPowerShell = powershellCommands.execPowerShell;
 
+  windowsStartRecordingScreen = recordScreenCommands.windowsStartRecordingScreen;
+  windowsStopRecordingScreen = recordScreenCommands.windowsStopRecordingScreen;
   startRecordingScreen = recordScreenCommands.startRecordingScreen;
   stopRecordingScreen = recordScreenCommands.stopRecordingScreen;
 

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -6,6 +6,7 @@ export const executeMethodMap = {
     params: {
       optional: [
         'timeLimit',
+        'videoFilter',
         'fps',
         'preset',
         'captureCursor',

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -2,7 +2,7 @@ import { ExecuteMethodMap } from '@appium/types';
 
 export const executeMethodMap = {
   'windows: startRecordingScreen': {
-    command: 'startRecordingScreen',
+    command: 'windowsStartRecordingScreen',
     params: {
       optional: [
         'timeLimit',
@@ -17,7 +17,7 @@ export const executeMethodMap = {
     },
   },
   'windows: stopRecordingScreen': {
-    command: 'stopRecordingScreen',
+    command: 'windowsStopRecordingScreen',
     params: {
       optional: [
         'remotePath',


### PR DESCRIPTION
Add missing parameter `videoFilter` to executeMethodMap of startRecordingScreen.
Recover default recording screen functions with default type of parameters.
`AppiumDriver.startRecordScreen()` `POST appium/start_recording_screen` `{"options": { ... }}`
`AppiumDriver.stopRecordScreen()` ..