### PR TITLE
fix: Remove trailing slash from proxyOpts for custom server URL

### DIFF
--- a/lib/winappdriver.js
+++ b/lib/winappdriver.js
@@ -234,7 +234,7 @@ export class WinAppDriver {
     /** @type {import('@appium/types').ProxyOptions} */
     const proxyOpts = {
       log: this.log,
-      base: parsedUrl.pathname,
+      base: _.trimEnd(parsedUrl.pathname, '/'),
       server: parsedUrl.hostname,
       port: parseInt(parsedUrl.port, 10),
       scheme: _.trimEnd(parsedUrl.protocol, ':'),


### PR DESCRIPTION
Thank you again for accepting my proposal for a change and implementing it so fast. It's just this small bug that's left to fix, so that it works with every possible custom WAD URL. Currently it doesn't work for URLs like this one: http://127.0.0.1:4723. For it, 2 slashes are added like that: http://127.0.0.1:4723//status. The fix fixes this only case where it doesn't work.