### PR TITLE
fix: fix type error

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { util, net } from 'appium/support';
 import { promisify } from 'node:util';
 import { exec } from 'node:child_process';
@@ -21,8 +22,12 @@ export async function shellExec(cmd, args = [], opts = {}) {
     timeoutMs = 60 * 1000 * 5
   } = opts;
   const fullCmd = util.quote([cmd, ...args]);
-  return await B.resolve(execAsync(fullCmd, opts))
+  const { stdout, stderr } = await B.resolve(execAsync(fullCmd, opts))
     .timeout(timeoutMs, `The command '${fullCmd}' timed out after ${timeoutMs}ms`);
+  return {
+    stdout: _.isString(stdout) ? stdout : stdout.toString(),
+    stderr: _.isString(stderr) ? stderr : stderr.toString(),
+  };
 }
 
 /**


### PR DESCRIPTION
to fix:

```
kazu $ npm run build

> appium-windows-driver@4.4.5 build
> tsc -b

lib/utils.js:24:3 - error TS2322: Type '{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }' is not assignable to type '{ stdout: string; stderr: string; }'.
  Types of property 'stdout' are incompatible.
    Type 'string | Buffer<ArrayBufferLike>' is not assignable to type 'string'.
      Type 'Buffer<ArrayBufferLike>' is not assignable to type 'string'.

24   return await B.resolve(execAsync(fullCmd, opts))
     ~~~~~~
```