### PR TITLE
feat: Update server compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Appium Windows Driver
 
 Appium Windows Driver is a test automation tool for Windows devices and acts as a proxy to Microsoft's [WinAppDriver server](https://github.com/microsoft/WinAppDriver). Appium Windows Driver supports testing Universal Windows Platform (UWP), Windows Forms (WinForms), Windows Presentation Foundation (WPF), and Classic Windows (Win32) apps on Windows 10 PCs. The server itself is maintained by Microsoft at https://github.com/microsoft/WinAppDriver. Check its [release notes](https://github.com/microsoft/WinAppDriver/releases) and the [vendor documentation](https://github.com/microsoft/WinAppDriver/tree/master/Docs) to get more details on the supported features and possible pitfalls.
 
-> [!NOTE]
->
-> Since version 2.0.0 Windows driver has dropped the support of Appium 1, and is only compatible to Appium 2. Use the `appium driver install --source=npm appium-windows-driver`
-> command to add it to your Appium 2 dist.
+> [!IMPORTANT]
+> Since major version *5.0.0*, this driver is only compatible with Appium 3. Use the `appium driver install --source=npm appium-windows-driver`
+> command to add it to your distribution.
 
 > [!WARNING]
 >

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/appium/appium-windows-driver/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "prettier": {
     "bracketSpacing": false,
@@ -58,7 +58,7 @@
     "portscanner": "^2.2.0",
     "semver": "^7.6.3",
     "source-map-support": "^0.x",
-    "teen_process": "^2.0.1"
+    "teen_process": "^3.0.0"
   },
   "scripts": {
     "build": "tsc -b",
@@ -71,22 +71,21 @@
     "e2e-test": "mocha --exit --timeout 10m \"./test/e2e/**/*-specs.js\""
   },
   "peerDependencies": {
-    "appium": "^2.4.0"
+    "appium": "^3.0.0-rc.2"
   },
   "optionalDependencies": {
     "koffi": "^2.8.1"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.x",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",
     "@types/lodash": "^4.14.196",
     "@types/mocha": "^10.0.1",
     "@types/node": "^24.0.0",
-    "@types/teen_process": "^2.0.2",
     "chai": "^5.1.1",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10
BREAKING CHANGE: Required Appium server version has been bumped to >=3.0.0-rc.2