### PR TITLE
fix: use full path instead of short path

### DIFF
--- a/scripts/install-wad.mjs
+++ b/scripts/install-wad.mjs
@@ -159,8 +159,9 @@ async function installWad(version) {
   const release = selectRelease(releases, version);
   const asset = selectAsset(release);
   const parsedName = path.parse(asset.name);
+  const realPath = await fs.realpath(tmpdir());
   const installerPath = path.join(
-    tmpdir(),
+    realPath,
     `${parsedName.name}_${(Math.random() + 1).toString(36).substring(7)}${parsedName.ext}`
   );
   log.info(`Will download and install v${release.version} from ${asset.url}`);


### PR DESCRIPTION
https://github.com/appium/appium-windows-driver/issues/324

It looks like https://nodejs.org/api/os.html#ostmpdir on the user env returned short path -> https://github.com/appium/appium-windows-driver/issues/324#issuecomment-3378863646
https://en.wikipedia.org/wiki/8.3_filename

Then, the short path doesn't work with `msiexec` I guess, then we should resolve it as a full path.

I hope this will work on the user env